### PR TITLE
Layout tweaks on gem page

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -157,6 +157,21 @@ page "*.json"
 # activate :automatic_image_sizes
 
 helpers do
+  def page_title
+    [config[:site_title], page_header, current_page.data.title].compact.join(' - ')
+  end
+
+  def page_header
+    current_page.data.name || recursive_name(current_page)
+  end
+
+  def recursive_name(page)
+    return nil unless page
+    return page.data.name if page.data.name
+
+    recursive_name(page.parent)
+  end
+
   def nav
     url = "#{current_resource.url.split('/')[0..2].join('/')}/"
     root = sitemap.resources.detect { |page| page.url == url }
@@ -191,8 +206,8 @@ helpers do
     root.data.sections.map do |name|
       page = pages.detect { |r| r.path.include?(name) }
       raise "section #{name} not found" unless page
-      page
-    end.map { |page| nav_link(page) }.join
+      nav_link(page)
+    end.join
   end
 
   # Returns a list of pages matching a specific type

--- a/source/gems/dry-component/index.html.md
+++ b/source/gems/dry-component/index.html.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction
 layout: gem-single
+name: dry-component
 type: gem
 sections:
   - container

--- a/source/gems/dry-logic/index.html.md
+++ b/source/gems/dry-logic/index.html.md
@@ -3,6 +3,7 @@ title: Introduction & Usage
 description: Predicate logic with composable rules
 layout: gem-single
 type: gem
+name: dry-logic
 ---
 
 Predicate logic and rule composition used by:

--- a/source/gems/dry-transaction/index.html.md
+++ b/source/gems/dry-transaction/index.html.md
@@ -4,6 +4,7 @@ description: Business transaction DSL
 layout: gem-single
 order: 7
 type: gem
+name: dry-transaction
 sections:
   - usage
 ---

--- a/source/gems/dry-types/index.html.md
+++ b/source/gems/dry-types/index.html.md
@@ -2,6 +2,7 @@
 title: Introduction
 layout: gem-single
 type: gem
+name: dry-types
 sections:
   - including-types
   - built-in-types

--- a/source/gems/dry-types/strict.html.md
+++ b/source/gems/dry-types/strict.html.md
@@ -1,7 +1,6 @@
 ---
 title: Strict
 layout: gem-single
-name: types
 order: 3
 ---
 

--- a/source/gems/dry-types/sum.html.md
+++ b/source/gems/dry-types/sum.html.md
@@ -1,7 +1,6 @@
 ---
 title: Sum
 layout: gem-single
-name: types
 order: 7
 ---
 

--- a/source/gems/dry-validation/comparison-with-activerecord.html.md
+++ b/source/gems/dry-validation/comparison-with-activerecord.html.md
@@ -1,7 +1,6 @@
 ---
 title: Comparison With ActiveRecord
 layout: gem-single
-name: types
 order: 10
 ---
 

--- a/source/layouts/gem-single.slim
+++ b/source/layouts/gem-single.slim
@@ -8,8 +8,8 @@ html lang="en"
         aside.sidebar
           ul
             li
-              == nav_header
               == nav
         article.gem-article
+          h2 = page.data.title
           = yield
     = partial "footer"

--- a/source/layouts/news-single.slim
+++ b/source/layouts/news-single.slim
@@ -2,7 +2,7 @@ doctype html
 html lang="en"
   head = partial("head")
   body
-    = partial "header"
+    = partial "header-news"
     .row
       .content-wrap
         article.news-article

--- a/source/partials/_head.html.slim
+++ b/source/partials/_head.html.slim
@@ -3,7 +3,7 @@ meta charset="utf-8"
   meta name="breakpoint" content=breakpoint.name media=breakpoint.query
 meta name="viewport" content="width=device-width, initial-scale=1.0"
 link href="/feed.xml" rel="alternate" type="application/atom+xml" title="dry-rb news"
-title = page.data.title
+title == page_title
 = stylesheet_link_tag "site"
 = javascript_include_tag "site", async: true
 javascript:

--- a/source/partials/_header-news.slim
+++ b/source/partials/_header-news.slim
@@ -1,0 +1,8 @@
+header
+ .content-wrap
+   = partial "nav"
+   .intro-page
+     h1 == page.data.title
+     - if page.data.author
+       span.news-article-meta
+         = "Published on #{I18n.l(current_page.data.date, format: :long)} by #{author_url}"

--- a/source/partials/_header.slim
+++ b/source/partials/_header.slim
@@ -2,7 +2,4 @@ header
  .content-wrap
    = partial "nav"
    .intro-page
-     h1 = page.data.title
-     - if page.data.author
-       span.news-article-meta
-         = "Published on #{I18n.l(current_page.data.date, format: :long)} by #{author_url}"
+     h1 == page_header


### PR DESCRIPTION
### Before:
![screen shot 2016-03-18 at 10 12 07 am](https://cloud.githubusercontent.com/assets/756722/13863975/14147032-ecf2-11e5-8dfc-b0b4dcc9c9d3.png)

### After:
![screen shot 2016-03-18 at 10 12 29 am](https://cloud.githubusercontent.com/assets/756722/13863976/1416c76a-ecf2-11e5-9f4e-3b45895f9f21.png)

- Display gem name in header
- Fix up page title to reflect gem name and page (i.e. `<title>dry-rb - dry-validation - Introduction</title>`)

This should fix issue #21