### PR TITLE
Add a Twitter widget to the home and news-single pages.

### DIFF
--- a/assets/stylesheets/site.css.scss
+++ b/assets/stylesheets/site.css.scss
@@ -419,16 +419,21 @@ hr {
 }
 
 .news-article {
-  @extend .news-list;
-}
+  @include col(2,3);
+  margin-left: calc(100% / 12 * 2);
 
-.news-article__aside {
-  float: right;
-  margin-left: 60px;
-  margin-bottom: 60px;
-  width: 400px;
-  @include tablet { display: none; }
-  @include mobile { display: none; }
+  @media (min-width: 320px)
+  and (max-width: 1199px) {
+   margin-left: 0;
+  }
+
+  @include tablet {
+    @include col (1,1);
+  }
+
+  @include mobile {
+    @include col (1,1);
+  }
 }
 
 .news__list-item {

--- a/assets/stylesheets/site.css.scss
+++ b/assets/stylesheets/site.css.scss
@@ -388,6 +388,28 @@ hr {
   padding-bottom: 70px;
 }
 
+.content-wrap--news-and-twitter {
+  @include clearfix-micro;
+}
+
+.section-news {
+  @include desktop {
+    float: left;
+    padding-right: 30px;
+    width: 55%;
+  }
+  @include tablet { padding-bottom: 30px; }
+  @include mobile { padding-bottom: 20px; }
+}
+
+.section-twitter {
+  @include desktop {
+    float: left;
+    padding-left: 30px;
+    width: 45%;
+  }
+}
+
 .news-article-meta {
   font-size: 90%;
   a:hover,
@@ -400,22 +422,13 @@ hr {
   @extend .news-list;
 }
 
-.news-list {
-  @include col(2,3);
-  margin-left: calc(100% / 12 * 2);
-
-  @media (min-width: 320px)
-  and (max-width: 1199px) {
-    margin-left: 0;
-  }
-
-  @include tablet {
-    @include col (1,1);
-  }
-
-  @include mobile {
-    @include col (1,1);
-  }
+.news-article__aside {
+  float: right;
+  margin-left: 60px;
+  margin-bottom: 60px;
+  width: 400px;
+  @include tablet { display: none; }
+  @include mobile { display: none; }
 }
 
 .news__list-item {
@@ -448,14 +461,13 @@ hr {
 
 .news__list-item-date {
   @include col(2,8);
-
-  @include mobile {
-    @include col(1,1);
-  }
-
   color: #666666;
   font-size: 14px;
   vertical-align: top;
+  @include mobile {
+    @include col(1,1);
+    p { margin-bottom: 10px; }
+  }
 }
 
 pre {

--- a/source/index.html.slim
+++ b/source/index.html.slim
@@ -31,14 +31,21 @@ title: Home
       | View all gems
 
 .row
-  .content-wrap
+  .content-wrap.content-wrap--news-and-twitter
     h2.section-heading News
-    ul.news-list
-      - blog.articles[0...5].each do |article|
-        li.news__list-item
-          a.news__list-item-anchor href= article.url
-            .news__list-item-date
-              p = article.date.strftime('%e %B %Y')
-            .news__list-item-content
-              h3 = article.title
-              = sanitize article.summary
+    .section-news
+      ul.news-list
+        - blog.articles[0...5].each do |article|
+          li.news__list-item
+            a.news__list-item-anchor href= article.url
+              .news__list-item-date
+                p = article.date.strftime('%e %B %Y')
+              .news__list-item-content
+                h3 = article.title
+                = sanitize article.summary
+    .section-twitter
+      / Twitter widget
+      a class="twitter-timeline" href="https://twitter.com/dry_rb" data-widget-id="712518119412117504"
+        | Tweets by @dry_rb
+      javascript:
+        !function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>

--- a/source/layouts/news-single.slim
+++ b/source/layouts/news-single.slim
@@ -6,5 +6,11 @@ html lang="en"
     .row
       .content-wrap
         article.news-article
+          .news-article__aside
+            / Twitter widget
+            a class="twitter-timeline" href="https://twitter.com/dry_rb" data-widget-id="712518119412117504"
+              | Tweets by @dry_rb
+            javascript:
+              !function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
           = yield
     = partial "footer"

--- a/source/layouts/news-single.slim
+++ b/source/layouts/news-single.slim
@@ -6,11 +6,5 @@ html lang="en"
     .row
       .content-wrap
         article.news-article
-          .news-article__aside
-            / Twitter widget
-            a class="twitter-timeline" href="https://twitter.com/dry_rb" data-widget-id="712518119412117504"
-              | Tweets by @dry_rb
-            javascript:
-              !function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
           = yield
     = partial "footer"


### PR DESCRIPTION
This PR adds a Twitter widget to both the home (in the "News" section) and news-single (as an aside on desktop width) pages (#37).

<img width="989" alt="screen shot 2016-03-31 at 3 55 41 pm" src="https://cloud.githubusercontent.com/assets/1016074/14165845/2f4849de-f759-11e5-92f1-656a75951d3c.png">
<img width="980" alt="screen shot 2016-03-31 at 3 55 35 pm" src="https://cloud.githubusercontent.com/assets/1016074/14165846/2f4b7f32-f759-11e5-8d4a-eac199bc6262.png">
