### PR TITLE
add an 'Introduction & Usage' for dry-monads

### DIFF
--- a/source/gems/dry-monads/index.html.md
+++ b/source/gems/dry-monads/index.html.md
@@ -1,0 +1,205 @@
+---
+title: Introduction & Usage
+description: Common monads for Ruby
+layout: gem-single
+type: gem
+name: dry-result_monads
+---
+
+## Introduction
+
+`dry-monads` is a set of common monads for Ruby.
+
+Monads provide an elegant way of handling errors, exceptions and chaining functions so that the code is much more understandable and has all the error handling, without all the `if`'s and `else`'s.
+
+See [dry-result_matcher](/gems/dry-result_matcher/) for an example of how to use monads for controlling the flow of code with a result.
+
+## Usage
+
+### Maybe monad
+
+The `Maybe` monad is used when a series of computations that could return `nil`
+at any point.
+
+#### `bind` or `>>`
+
+```ruby
+require 'dry-monads'
+
+M = Dry::Monads
+
+maybe_user = M.Maybe(user).bind do |u|
+  M.Maybe(user.address).bind do |a|
+    M.Maybe(a.street)
+  end
+end
+
+# If user with address exists
+# => Some("Street Address")
+# If user or address is nil
+# => None()
+
+# You also can pass a proc to #bind
+
+add_two = -> x { x + 2 }
+
+M.Maybe(5).bind(add_two).bind(add_two) # => Some(9)
+
+# >> (right shift) is an alias for bind
+
+M.Maybe >> :succ.to_proc >> add_two # => Some(8)
+```
+
+#### `fmap`
+
+Similar to `bind` but lifts the result for you.
+
+```ruby
+require 'dry-monads'
+
+Dry::Monads::Maybe(user).fmap(&:address).fmap(&:street)
+
+# If user with address exists
+# => Some("Street Address")
+# If user or address is nil
+# => None()
+```
+
+### Either monad
+
+The `Either` monad is useful to express a series of computations that might
+return an error object with additional information.
+
+The `Either` mixin has two type constructors: `Right` and `Left`. The `Right`
+can be thought of as "everything went right" and the `Left` is used when
+"something has gone wrong".
+
+#### `Either::Mixin`
+
+```ruby
+require 'dry-monads'
+
+class EitherCalculator
+  include Dry::Monads::Either::Mixin
+
+  attr_accessor :input
+
+  def calculate
+    i = Integer(input)
+
+    Right(i).bind do |value|
+      if value > 1
+        Right(value + 3)
+      else
+        Left("value was less than 1")
+      end
+    end.bind do |value|
+      if value % 2 == 0
+        Right(value * 2)
+      else
+        Left("value was not even")
+      end
+    end
+  end
+end
+
+# EitherCalculator instance
+c = EitherCalculator.new
+
+# If everything went right
+c.input = 3
+result = c.calculate
+result # => Right(12)
+result.value # => 12
+
+# If if failed in the first block
+c.input = 0
+result = c.calculate
+result # => Left("value was less than 1")
+result.value # => "value was less than 1"
+
+# if it failed in the second block
+c.input = 2
+result = c.calculate
+result # => Left("value was not even")
+result.value # => "value was not even"
+```
+
+#### `fmap`
+
+An example of using `fmap` with `Right` and `Left`.
+
+```ruby
+require 'dry-monads'
+
+M = Dry::Monads
+
+result = if foo > bar
+  M.Right(10)
+else
+  M.Left("wrong")
+end.fmap { |x| x * 2 }
+
+# If everything went right
+result # => Right(20)
+# If it did not
+result # => Left("wrong")
+
+# #fmap accepts proc as well as #bind
+
+upcase = :upcase.to_proc
+
+M.Right('hello').fmap(upcase) # => Right("HELLO")
+```
+
+#### `or`
+
+An example of using `or` with `Right` and `Left`.
+
+```ruby
+M = Dry::Monads
+
+M.Right(10).or(M.Right(99)) # => Right(10)
+M.Left("error").or(M.Left("new error")) # => Left("new error")
+M.Left("error").or { |err| M.Left("new #{err}") } # => Left("new error")
+```
+
+#### `to_maybe`
+
+Sometimes it's useful to turn an `Either` into a `Maybe`.
+
+```ruby
+require 'dry-monads'
+
+result = if foo > bar
+  Dry::Monads.Right(10)
+else
+  Dry::Monads.Left("wrong")
+end.to_maybe
+
+# If everything went right
+result # => Some(10)
+# If it did not
+result # => None()
+```
+
+### Try monad
+
+Examples of using the `Try` monad.
+
+```ruby
+require 'dry-monads'
+
+extend Dry::Monads::Try::Mixin
+
+res = Try() { 10 / 2 }
+res.value if res.success?
+# => 5
+
+res = Try() { 10 / 0 }
+res.exception if res.failure?
+# => #<ZeroDivisionError: divided by 0>
+
+Try(NoMethodError, NotImplementedError) { 10 / 0 }
+# => raise ZeroDivisionError: divided by 0 exception
+```


### PR DESCRIPTION
I've added an Introduction & Usage for `dry-monads`. The "Usage" is mostly a copy from the repos README.md. Once this has been merged and published the "Usage" section of the README can be replaced with a link to documentation like other dry-rb gems.