### PR TITLE
Document nested array schemas

### DIFF
--- a/source/gems/dry-validation/nested-data.html.md
+++ b/source/gems/dry-validation/nested-data.html.md
@@ -64,3 +64,20 @@ puts errors.inspect
 #   }
 # }
 ```
+
+You can specify array of schemas as well:
+
+``` ruby
+schema = Dry::Validation.Schema do
+  key(:phone_numbers).each do
+    key(:country_code).required
+    key(:area_code).required
+    key(:number).required
+  end
+end
+
+errors = schema.call(phone_numbers: [{ country_code: "1", area_code: "613", number: "6006789" }]).messages
+
+puts errors.inspect
+# {}
+```


### PR DESCRIPTION
It took me a while to figure out why the following schema doesn't work:

```ruby
Dry::Validation.Form do
  key(:line_items).each do
    schema do
      key(:quantity)
      key(:price)
    end
  end
end
```

It turned out that `schema` block prevented this schema from working.

Let's fix that in docs.
For future, it would be great to have a schema validator in dry-validation.

cc @nepalez @davydovanton