### PR TITLE
fixed empty example

### DIFF
--- a/source/gems/dry-validation/basics/built-in-predicates.html.md
+++ b/source/gems/dry-validation/basics/built-in-predicates.html.md
@@ -106,9 +106,9 @@ describe 'empty?' do
   end
 
   it 'with regular ruby' do
-    assert !{sample: ""}[:sample].empty?
-    assert !{sample: []}[:sample].empty?
-    assert !{sample: {}}[:sample].empty?
+    assert {sample: ""}[:sample].empty?
+    assert {sample: []}[:sample].empty?
+    assert {sample: {}}[:sample].empty?
   end
 
   it 'with dry-validation' do


### PR DESCRIPTION
In 'with regular ruby' block, asserts were inverted - the values ARE empty, but the assertions checked that they are NOT.