### PR TITLE
dry-validation 'Optional keys and values' updated

### DIFF
--- a/source/gems/dry-validation/optional-keys-and-values.html.md
+++ b/source/gems/dry-validation/optional-keys-and-values.html.md
@@ -5,7 +5,7 @@ layout: gem-single
 
 We make a clear distinction between specifying an optional `key` and an optional `value`. This gives you a way of being very specific about validation rules. You can define a schema which can give you precise errors when a key was missing or key was present but the value was nil.
 
-This also comes with the benefit of being explicit about the type expectation.  In the example below we explicitly state that `:age` *can be nil* or it *can be an integer* and when it *is an integer* we specify that it *must be greater than 18*.
+This also comes with the benefit of being explicit about the type expectation. In the example below we explicitly state that `:age` *can be omitted* or if present it *must be an integer* and it *must be greater than 18*.
 
 You can define which keys are optional and define rules for their values:
 


### PR DESCRIPTION
You state that you 'make a clear distinction between specifying an optional `key` and an optional `value`' but the example description below is actually misleading - the age key in the example is optional, but if it is present, the value MUST be filled. It can NOT be nil as you say.