### PR TITLE
dry-validation 'High-level Rules' updated

### DIFF
--- a/source/gems/dry-validation/high-level-rules.html.md
+++ b/source/gems/dry-validation/high-level-rules.html.md
@@ -16,7 +16,7 @@ schema = Dry::Validation.Schema do
   required(:sample_number).maybe(:int?)
 
   rule(barcode_only: [:barcode, :job_number, :sample_number]) do |barcode, job_num, sample_num|
-    barcode.filled? & (job_num.none? & sample_num.none?)
+    barcode.filled? > (job_num.none? & sample_num.none?)
   end
 end
 ```


### PR DESCRIPTION
The description says that we're checking that 'when barcode is provided both job and sample numbers are not provided' but the rule definition as it was `barcode.filled? & (job_num.none? & sample_num.none?)` actually required barcode to be filled. What we need here is the `>` then operator.