### PR TITLE
dry-container 'Brief Example' updated

### DIFF
--- a/source/gems/dry-container/index.html.md
+++ b/source/gems/dry-container/index.html.md
@@ -17,11 +17,10 @@ Making use of the dependency inversion principle, with an IoC container and low-
 
 ```ruby
 container = Dry::Container.new
-container.register(:parrot) { |a| puts a }
+container.register(:parrot) { puts "Hello world" }
 
-parrot = container.resolve(:parrot)
-parrot.call("Hello World")
-# Hello World
+container.resolve(:parrot)
+# >> Hello World
 # => nil
 ```
 


### PR DESCRIPTION
The example resolved an item which was registered using a block without `call: false` option param and then called it explicitly. This would result in a `NoMethodError` - undefined call for `nil` (which is what puts returns).
