### PR TITLE
dry-types Added an example of callable value to documatation

### DIFF
--- a/source/gems/dry-types/default-values.html.md
+++ b/source/gems/dry-types/default-values.html.md
@@ -22,3 +22,13 @@ PostStatus = Types::Form::String.default('draft')
 PostStatus[''] # "draft"
 PostStatus["published"] # "published"
 ```
+
+It works with a callable value:
+
+``` ruby
+CallableDateTime = Types::DateTime.default { DateTime.now }
+
+CallableDateTime[nil] # Sun, 07 Aug 2016 23:52:04 -0400
+CallableDateTime[nil] # Sun, 07 Aug 2016 23:52:05 -0400
+```
+


### PR DESCRIPTION
Hey, noticed that there is no documentation on how to create callable value. Here is a fix for that. Let me know if this requires any changes.