### PR TITLE
dry-system 'Booting a Dependency' uses => use method rename

### DIFF
--- a/source/gems/dry-system/booting.html.md
+++ b/source/gems/dry-system/booting.html.md
@@ -72,7 +72,7 @@ end
 
 ### Using other bootable dependencies
 
-It is often needed to use another dependency when booting a component, you can use a convenient `uses` API for that, it will auto-boot required dependency
+It is often needed to use another dependency when booting a component, you can use a convenient `use` API for that, it will auto-boot required dependency
 and make it available in the booting context:
 
 ``` ruby
@@ -84,7 +84,7 @@ end
 
 # system/boot/db.rb
 Application.finalize(:db) do |container|
-  uses :logger
+  use :logger
   container.register(DB.new(ENV['DB_URL'], logger: logger))
 end
 ```


### PR DESCRIPTION
In `Dry::System::Lifecycle` there is [`use`](https://github.com/dry-rb/dry-system/blob/08b2ce3088810c46fb89555f62dbc724eddcf5ce/lib/dry/system/lifecycle.rb#L72) method. Docs, on the other hand, [state](http://dry-rb.org/gems/dry-system/booting/) that `uses`  is the right API.