### PR TITLE
dry-system 'Booting a Dependency' Component => System module rename

### DIFF
--- a/source/gems/dry-system/booting.html.md
+++ b/source/gems/dry-system/booting.html.md
@@ -28,7 +28,7 @@ After defining the finalization block our container will not call it until its o
 
 ``` ruby
 # under /my/app/boot/container.rb
-class Application < Dry::Component::Container
+class Application < Dry::System::Container
   configure do |config|
     config.root = Pathname('/my/app')
   end


### PR DESCRIPTION
The example for booting a specific dependency shows that container class should inherit from `Dry::Component::Container`. However, `Container` is defined under [`Dry::System`](https://github.com/dry-rb/dry-system/blob/master/lib/dry/system/container.rb#L62) module.