### PR TITLE
Fix documentation error

### DIFF
--- a/source/gems/dry-auto_inject/index.html.md
+++ b/source/gems/dry-auto_inject/index.html.md
@@ -40,7 +40,7 @@ class CreateUser
   end
 end
 
-create_user = MyContainer["create_user"]
+create_user = MyContainer["operations.create_user"]
 create_user.call(name: "Jane")
 ```
 


### PR DESCRIPTION
If I run the code in index.md I get an error: 

2.3.1 :022 > create_user = MyContainer["create_user"]
Dry::Container::Error: Nothing registered with the key "create_user"