### PR TITLE
Fix typos in `dry-matcher` documentation

### DIFF
--- a/source/gems/dry-matcher/class-enhancement.html.md
+++ b/source/gems/dry-matcher/class-enhancement.html.md
@@ -9,7 +9,7 @@ You can offer a match block API from your own methods using `Dry::Matcher.for`:
 require "dry-matcher"
 
 # First, build a matcher or use an existing one (like dry-matcher's EitherMatcher)
-MyMatcher = DryMatcher.new(...)
+MyMatcher = Dry::Matcher.new(...)
 
 # Offer it from your class with `Dry::Matcher.for`
 class MyOperation

--- a/source/gems/dry-matcher/either-matcher.html.md
+++ b/source/gems/dry-matcher/either-matcher.html.md
@@ -13,11 +13,11 @@ value = Dry::Monads::Either::Right.new("success!")
 
 result = Dry::Matcher::EitherMatcher.(value) do |m|
   m.success do |v|
-    puts "Yay: #{v}"
+    "Yay: #{v}"
   end
 
   m.failure do |v|
-    puts "Boo: #{v}"
+    "Boo: #{v}"
   end
 end
 


### PR DESCRIPTION
The class enhancement example had used undefined constant `DryMatcher` before the fix.
In EitherMatcher example Before the fix result would be equal `nil` instead of `"Yay: success!"`, since `Kernel#puts` does not return printed value.