### PR TITLE
Missing #call in documentation

### DIFF
--- a/source/gems/dry-view/index.html.md
+++ b/source/gems/dry-view/index.html.md
@@ -59,7 +59,7 @@ Then `#call` your view controller to render your view:
 
 ```ruby
 view = HelloView.new
-view.(greeting: "Greetings from dry-rb")
+view.call(greeting: "Greetings from dry-rb")
 # => "<html><body><h1>Hello!</h1><p>Greetings from dry-rb!</p></body></html>
 ```
 


### PR DESCRIPTION
Forgive me if I'm wrong... it looks like the "Then `#call` your view controller to render your view" example is missing the `#call` call.

Haven't used this library yet, so I'm just guessing. This looked odd. Again sorry if I'm wrong!

Neat library!