### PR TITLE
Add github url with "help wanted" tag on community page

### DIFF
--- a/source/community.html.slim
+++ b/source/community.html.slim
@@ -9,7 +9,7 @@ p
   | dry-rb is here to help you build better Ruby apps. Our collection of gems is growing and evolving, and we welcome your contributions!
 
 p
-  | To get started, try out the gems and share your stories or questions in <a href="http://discuss.dry-rb.org/"><strong>our discussion forum</strong></a>. Find a bug or want to fix one? Share your <a href="http://github.com/dry-rb"><strong>issues or pull requests on GitHub</strong></a>. You can also <a href="http://gitter.im/dry-rb/chat"><strong>find us on Gitter</strong></a> for development-focused chat.
+  | To get started, try out the gems and share your stories or questions in <a href="http://discuss.dry-rb.org/"><strong>our discussion forum</strong></a>. Find a bug or <a href="https://github.com/search?utf8=✓&q=user%3Adry-rb+is%3Aopen+label%3A"help+wanted""><strong>want to fix one</strong></a>? Share your <a href="http://github.com/dry-rb"><strong>issues or pull requests on GitHub</strong></a>. You can also <a href="http://gitter.im/dry-rb/chat"><strong>find us on Gitter</strong></a> for development-focused chat.
 p
   | We are committed to fostering a welcoming community. dry-rb adheres to a <a href="/conduct">Contributor Code of Conduct</a>. By participating in the dry-rb community, you are expected to abide by its terms. Please report unacceptable behavior to a core team member.
 


### PR DESCRIPTION
Add github search url with "help wanted" tag to makes easier to find issues to collaborate