### PR TITLE
Fix typos in dry-types/custom-types

### DIFF
--- a/source/gems/dry-types/custom-types.html.md
+++ b/source/gems/dry-types/custom-types.html.md
@@ -28,11 +28,11 @@ valid['invalid']
 
 ### `Types.Constant`
 
-`Types.Value` builds a type that checks a value for identity (using `equal?`).
+`Types.Constant` builds a type that checks a value for identity (using `equal?`).
 
 ```ruby
-valid = Types.Value(:valid)
-valid[:valid] # => 'valid'
+valid = Types.Constant(:valid)
+valid[:valid] # => :valid
 valid[:invalid]
 # => Dry::Types::ConstraintError: :invalid violates constraints (is?(:valid, :invalid) failed)
 ```


### PR DESCRIPTION
In the `Types.Constant` section: 

* `Types.Value` &rarr; `Types.Constant`,
* `Symbol` &rarr; `String` as the result of applying the type to input.