### PR TITLE
Replace `Types::Array#member` to `Types::Array#of`

### DIFF
--- a/source/gems/dry-types/array-with-member.html.md
+++ b/source/gems/dry-types/array-with-member.html.md
@@ -7,7 +7,7 @@ name: dry-types
 The built-in array type supports defining the member's type:
 
 ``` ruby
-PostStatuses = Types::Strict::Array.member(Types::Coercible::String)
+PostStatuses = Types::Strict::Array.of(Types::Coercible::String)
 
 PostStatuses[[:foo, :bar]] # ["foo", "bar"]
 ```


### PR DESCRIPTION
* https://github.com/dry-rb/dry-types/blob/v0.12.2/CHANGELOG.md#deprecated