### PR TITLE
dry-transaction 0.11 docs

### DIFF
--- a/source/gems/dry-transaction/around-steps.html.md
+++ b/source/gems/dry-transaction/around-steps.html.md
@@ -1,0 +1,45 @@
+---
+title: Around steps
+layout: gem-single
+name: dry-transaction
+---
+
+Regular `step` operations take an input, act on it, and return an output to pass to the next step. They operate in sequence, with control being passed from one operation to the next.
+
+Sometimes, a step operation needs to _wrap_ all of the subsequent steps. A common case for this is handling database transactions. An operation providing a database transaction across steps needs to wrap around all the subsequent operations so it can roll back the transactoin in case one of the operations failures.
+
+Use an `around` step to give an operation this behaviour. The operation will receive `#call(input, &block)`, where `&block` is the collection of steps it is wrapping. It should call the block to run those steps and handle as appropriate.
+
+An operation to wrap steps in a database transaction would work like this (replace `MyDB` with whatever your database system requires):
+
+```ruby
+class MyContainer
+  extend Dry::Container
+
+  register(:transaction) do |input, &block|
+    result = nil
+
+    begin
+      MyDB.transaction do
+        result = block.(Success(input))
+        raise MyDB::Rollback if result.failure?
+        result
+      end
+    rescue Test::Rollback
+      result
+    end
+  end
+end
+```
+
+And can be integrated into a business transaction like this:
+
+```ruby
+class MyOperation
+  include Dry::Transaction(container: MyContainer)
+
+  around :transaction
+  step :persist_something
+  step :persist_another_thing
+end
+```

--- a/source/gems/dry-transaction/custom-step-adapters.html.md
+++ b/source/gems/dry-transaction/custom-step-adapters.html.md
@@ -4,7 +4,7 @@ layout: gem-single
 name: dry-transaction
 ---
 
-You can provide your own step adapters to add custom behaviour to transaction steps. Your step adapters must provide a single `#call(step, input, *args)` method, which should return the step’s result wrapped in an `Either` object.
+You can provide your own step adapters to add custom behaviour to transaction steps. Your step adapters must provide a single `#call(step, input, *args)` method, which should return the step’s result wrapped in a `Result` object.
 
 You can provide your step adapter in a few different ways. You can add it to the built-in `StepAdapters` container (a [`dry-container`](http://dry-rb.org/gems/dry-container)) to make it available to all transactions in your codebase:
 
@@ -36,7 +36,7 @@ class MyStepAdapters < Dry::Transaction::StepAdapters
     # In a real app, this would push the operation into a background worker queue
     QUEUE << step.operation.call(input, *args)
 
-    Dry::Monads.Right(input)
+    Dry::Monads.Success(input)
   }
 end
 

--- a/source/gems/dry-transaction/index.html.md
+++ b/source/gems/dry-transaction/index.html.md
@@ -31,7 +31,7 @@ sections:
 
 Requiring a business transaction’s steps to be independent operations directly addressable via a container means that they can be tested in isolation and easily reused throughout your application. The business transaction can then become a simple series of declarative steps, which ensures that it’s easy to understand at a glance.
 
-The output of each step is a [dry-monads](https://github.com/dry-rb/dry-monads) `Either` object (`Right` for success or `Left` for failure). This allows the steps to be chained together and ensures that processing stops in the case of a failure. Returning an `Either` from the overall transaction also allows for error handling to remain a primary concern without it getting in the way of tidy, straightforward operation logic.
+The output of each step is a [dry-monads](https://github.com/dry-rb/dry-monads) `Result` object (either a `Success` or `Failure`). This allows the steps to be chained together and ensures that processing stops in the case of a failure. Returning a `Result` from the overall transaction also allows for error handling to remain a primary concern without it getting in the way of tidy, straightforward operation logic.
 
 ## Links
 

--- a/source/gems/dry-transaction/index.html.md
+++ b/source/gems/dry-transaction/index.html.md
@@ -10,6 +10,7 @@ sections:
   - wrapping-operations
   - injecting-operations
   - step-notifications
+  - around-steps
   - step-adapters
   - custom-step-adapters
 ---

--- a/source/gems/dry-transaction/injecting-operations.html.md
+++ b/source/gems/dry-transaction/injecting-operations.html.md
@@ -19,10 +19,10 @@ class CreateUser
   step :persist, with: "operations.persist"
 end
 
-substitute_validate_step = -> input { Left(:definitely_not_valid) }
+substitute_validate_step = -> input { Failure(:definitely_not_valid) }
 
 create_user = CreateUser.new(validate: substitute_validate_step)
 
 create_user.call("name" => "Jane", "email" => "jane@doe.com")
-# => Left(:definitely_not_valid)
+# => Failure(:definitely_not_valid)
 ```

--- a/source/gems/dry-transaction/step-adapters.html.md
+++ b/source/gems/dry-transaction/step-adapters.html.md
@@ -6,9 +6,10 @@ name: dry-transaction
 
 `step` adds operations to your transaction that already return a `Result` object. If you have to work with other types of operations, you can use an alternative _step adapter_. Step adapters can wrap the output of your operations to make them easier to integrate into a transaction. The following adapters are available:
 
-* `map` – any output is considered successful and returned as `Success(output)`
-* `try` – the operation may raise an exception in an error case. This is caught and returned as `Failure(exception)`. The output is otherwise returned as `Success(output)`.
-* `tee` – the operation interacts with some external system and has no meaningful output. The original input is passed through and returned as `Success(input)`.
+- `map` – any output is considered successful and returned as `Success(output)`
+- `check` - the operation returns a boolean. True values are return the original input as `Success(input)`. Any other values return the original input as `Failure(input)`.
+- `try` – the operation may raise an exception in an error case. This is caught and returned as `Failure(exception)`. The output is otherwise returned as `Success(output)`.
+- `tee` – the operation interacts with some external system and has no meaningful output. The original input is passed through and returned as `Success(input)`.
 
 These step adapters in use look like this:
 

--- a/source/gems/dry-transaction/step-adapters.html.md
+++ b/source/gems/dry-transaction/step-adapters.html.md
@@ -4,11 +4,11 @@ layout: gem-single
 name: dry-transaction
 ---
 
-`step` adds operations to your transaction that already return an `Either` object. If you have to work with other types of operations, you can use an alternative _step adapter_. Step adapters can wrap the output of your operations to make them easier to integrate into a transaction. The following adapters are available:
+`step` adds operations to your transaction that already return a `Result` object. If you have to work with other types of operations, you can use an alternative _step adapter_. Step adapters can wrap the output of your operations to make them easier to integrate into a transaction. The following adapters are available:
 
-* `map` – any output is considered successful and returned as `Right(output)`
-* `try` – the operation may raise an exception in an error case. This is caught and returned as `Left(exception)`. The output is otherwise returned as `Right(output)`.
-* `tee` – the operation interacts with some external system and has no meaningful output. The original input is passed through and returned as `Right(input)`.
+* `map` – any output is considered successful and returned as `Success(output)`
+* `try` – the operation may raise an exception in an error case. This is caught and returned as `Failure(exception)`. The output is otherwise returned as `Success(output)`.
+* `tee` – the operation interacts with some external system and has no meaningful output. The original input is passed through and returned as `Success(input)`.
 
 These step adapters in use look like this:
 

--- a/source/gems/dry-transaction/wrapping-operations.html.md
+++ b/source/gems/dry-transaction/wrapping-operations.html.md
@@ -30,5 +30,5 @@ end
 
 create_user = CreateUser.new
 create_user.call("name" => "Jane", "email" => "jane@doe.com")
-# => Right({:name=>"JANE", :email=>"JANE@DOE.COM"})
+# => Success({:name=>"JANE", :email=>"JANE@DOE.COM"})
 ```


### PR DESCRIPTION
- Updates to refer to `Result` instead of `Either` monad
- Updates to notifications API
- Add note about `check` step
- Add page for `around` steps