### PR TITLE
Fix typo where required should be filled

### DIFF
--- a/source/gems/dry-validation/comparison-with-activemodel.html.md
+++ b/source/gems/dry-validation/comparison-with-activemodel.html.md
@@ -194,7 +194,7 @@ validates :attr, format: { with: regex }
 **dry-validation**
 
 ```ruby
-required(:attr).required(format?: regex)
+required(:attr).filled(format?: regex)
 ```
 
 #### Doesn't Match


### PR DESCRIPTION
I think that a typo made its way into the comparison page between validations in ActiveModel and dry-validations.

If you [read carefully here](http://dry-rb.org/gems/dry-validation/comparison-with-activemodel/#2-5-format) you can see that it says to use `required(:attr).required(format?: regex)` but I think it was meant to be `required(:attr).filled(format?: regex)`.

Am I right?

Thanks for the good job on dry-rb.