### PR TITLE
dry-transaction: General spruce up & clarification of operation injection

### DIFF
--- a/source/gems/dry-transaction/around-steps.html.md
+++ b/source/gems/dry-transaction/around-steps.html.md
@@ -8,7 +8,7 @@ Regular `step` operations take an input, act on it, and return an output to pass
 
 Sometimes, a step operation needs to _wrap_ all of the subsequent steps. A common case for this is handling database transactions. An operation providing a database transaction across steps needs to wrap around all the subsequent operations so it can roll back the transactoin in case one of the operations failures.
 
-Use an `around` step to give an operation this behaviour. The operation will receive `#call(input, &block)`, where `&block` is the collection of steps it is wrapping. It should call the block to run those steps and handle as appropriate.
+Use an `around` step to give an operation this behavior. The operation will receive `#call(input, &block)`, where `&block` is the collection of steps it is wrapping. It should call the block to run those steps and handle as appropriate.
 
 An operation to wrap steps in a database transaction would work like this (replace `MyDB` with whatever your database system requires):
 

--- a/source/gems/dry-transaction/around-steps.html.md
+++ b/source/gems/dry-transaction/around-steps.html.md
@@ -25,7 +25,7 @@ class MyContainer
         raise MyDB::Rollback if result.failure?
         result
       end
-    rescue Test::Rollback
+    rescue MyDB::Rollback
       result
     end
   end

--- a/source/gems/dry-transaction/around-steps.html.md
+++ b/source/gems/dry-transaction/around-steps.html.md
@@ -16,7 +16,7 @@ An operation to wrap steps in a database transaction would work like this (repla
 class MyContainer
   extend Dry::Container
 
-  register(:transaction) do |input, &block|
+  registe "transaction" do |input, &block|
     result = nil
 
     begin
@@ -38,10 +38,10 @@ And can be integrated into a business transaction like this:
 class MyOperation
   include Dry::Transaction(container: MyContainer)
 
-  around :transaction
+  around :transaction, with: "transaction"
 
   # Multiple subsequent steps writing to the database
-  step :persist_user
-  step :persist_account
+  step :create_user, with: "users.create"
+  step :create_account, with: "accounts.create"
 end
 ```

--- a/source/gems/dry-transaction/around-steps.html.md
+++ b/source/gems/dry-transaction/around-steps.html.md
@@ -39,7 +39,9 @@ class MyOperation
   include Dry::Transaction(container: MyContainer)
 
   around :transaction
-  step :persist_something
-  step :persist_another_thing
+
+  # Multiple subsequent steps writing to the database
+  step :persist_user
+  step :persist_account
 end
 ```

--- a/source/gems/dry-transaction/basic-usage.html.md
+++ b/source/gems/dry-transaction/basic-usage.html.md
@@ -33,7 +33,7 @@ end
 
 You can also define a transaction that relies upon operation objects in a container. Each operation must respond to `#call(input)`.
 
-The operations will be resolved from the container via `#[]`. For this example, we’ll use [dry-container](/gems/dry-container):
+The container will be checked for the operations using `#key?`, and the operations will be resolved from the container via `#[]`. For this example, we’ll use [dry-container](/gems/dry-container):
 
 ```ruby
 require "dry/container"

--- a/source/gems/dry-transaction/basic-usage.html.md
+++ b/source/gems/dry-transaction/basic-usage.html.md
@@ -15,7 +15,7 @@ class CreateUser
   include Dry::Transaction
 
   step :validate
-  step :persist
+  step :create
 
   private
 
@@ -23,7 +23,7 @@ class CreateUser
     # returns Success(valid_data) or Failure(validation)
   end
 
-  def persist(input)
+  def create(input)
     # returns Success(user)
   end
 end
@@ -40,19 +40,21 @@ require "dry/container"
 require "dry/transaction"
 require "dry/transaction/operation"
 
-class Validate
-  include Dry::Transaction::Operation
+module Users
+  class Validate
+    include Dry::Transaction::Operation
 
-  def call(input)
-    # returns Success(valid_data) or Failure(validation)
+    def call(input)
+      # returns Success(valid_data) or Failure(validation)
+    end
   end
-end
 
-class Persist
-  include Dry::Transaction::Operation
+  class Create
+    include Dry::Transaction::Operation
 
-  def call(input)
-    # returns Success(user)
+    def call(input)
+      # returns Success(user)
+    end
   end
 end
 
@@ -61,11 +63,11 @@ class Container
 
   namespace "users" do
     register "validate" do
-      Validate.new
+      Users::Validate.new
     end
 
-    register "persist" do
-      Persist.new
+    register "create" do
+      Users::Create.new
     end
   end
 end
@@ -80,7 +82,7 @@ class CreateUser
   include Dry::Transaction(container: Container)
 
   step :validate, with: "users.validate"
-  step :persist, with: "users.persist"
+  step :create, with: "users.create"
 end
 ```
 
@@ -98,7 +100,7 @@ class CreateUser
 
   # Operations will be resolved from the `Container` specified above
   step :validate, with: "users.validate"
-  step :persist, with: "users.persist"
+  step :create, with: "users.create"
 end
 ```
 
@@ -145,7 +147,7 @@ class CreateUser
   include Dry::Transaction(container: Container)
 
   step :validate
-  step :persist
+  step :create
   step :notify
 
   private
@@ -154,7 +156,7 @@ class CreateUser
     # ...
   end
 
-  def persist(input, account_id:)
+  def create(input, account_id:)
     # ...
   end
 
@@ -167,7 +169,7 @@ create_user = CreateUser.new
 
 create_user
   .with_step_args(
-    persist: [account_id: 123],
+    create: [account_id: 123],
     notify: ["foo@bar.com"],
   )
   .call(name: "Jane", email: "jane@doe.com")

--- a/source/gems/dry-transaction/basic-usage.html.md
+++ b/source/gems/dry-transaction/basic-usage.html.md
@@ -126,7 +126,7 @@ create_user.call(name: "Jane", email: "jane@doe.com") do |m|
   end
 
   m.failure do |error|
-    # Runs for any failure (including :validate failures)
+    # Runs for any other failure
     puts "Couldn’t create this user."
   end
 end

--- a/source/gems/dry-transaction/custom-step-adapters.html.md
+++ b/source/gems/dry-transaction/custom-step-adapters.html.md
@@ -43,7 +43,7 @@ end
 class CreateUser
   include Dry::Transaction(container: Container, step_adapters: MyStepAdapters)
 
-  step :persist
+  step :create
   enqueue :send_welcome_email
 end
 ```

--- a/source/gems/dry-transaction/index.html.md
+++ b/source/gems/dry-transaction/index.html.md
@@ -15,22 +15,45 @@ sections:
   - custom-step-adapters
 ---
 
-`dry-transaction` is a business transaction DSL. It provides a simple way to define a complex business transaction that includes processing by many different objects. It makes error handling a primary concern by using a “[Railway Oriented Programming](http://fsharpforfunandprofit.com/rop/)” approach for capturing and returning errors from any step in the transaction.
+dry-transaction is a business transaction DSL. It provides a simple way to define a complex business transaction that includes processing over many steps and by many different objects. It makes error handling a primary concern by taking a “[Railway Oriented Programming](http://fsharpforfunandprofit.com/rop/)” approach to capturing and returning errors from any step in the transaction.
 
 `dry-transaction` is based on the following ideas:
 
-* A business transaction is a series of operations where any can fail and stop the processing.
-* A business transaction may resolve its operations using an external container.
-* A business transaction can describe its steps on an abstract level without being coupled to any details about how individual operations work.
-* A business transaction doesn’t have any state.
-* Each operation shouldn’t accumulate state, instead it should receive an input and return an output without causing any side-effects.
-* The only interface of an operation is `#call(input)`.
-* Each operation provides a meaningful piece of functionality and can be reused.
-* Errors in any operation can be easily caught and handled as part of the normal application flow.
+- A business transaction is a series of operations where any can fail and stop the processing.
+- A business transaction may resolve its operations using an external container.
+- A business transaction can describe its steps on an abstract level without being coupled to any details about how individual operations work.
+- A business transaction doesn’t have any state.
+- Each operation shouldn’t accumulate state, instead it should receive an input and return an output without causing any side-effects.
+- The only interface of an operation is `#call(input)`.
+- Each operation provides a meaningful piece of functionality and can be reused.
+- Errors in any operation should be easily caught and handled as part of the normal application flow.
+
+A simple transaction may look like this:
+
+```ruby
+require "dry/transaction"
+
+class CreateUser
+  include Dry::Transaction
+
+  step :validate
+  step :persist
+
+  private
+
+  def validate(input)
+    # returns Success(valid_data) or Failure(validation)
+  end
+
+  def persist(input)
+    # returns Success(user)
+  end
+end
+```
 
 ## Why?
 
-Requiring a business transaction’s steps to be independent operations directly addressable via a container means that they can be tested in isolation and easily reused throughout your application. The business transaction can then become a simple series of declarative steps, which ensures that it’s easy to understand at a glance.
+Allowing a business transaction’s steps to be independent operations directly addressable via a container means that they can be tested in isolation and easily reused throughout your application. The business transaction can then become a series of declarative steps, which ensures that it’s easy to understand at a glance.
 
 The output of each step is a [dry-monads](https://github.com/dry-rb/dry-monads) `Result` object (either a `Success` or `Failure`). This allows the steps to be chained together and ensures that processing stops in the case of a failure. Returning a `Result` from the overall transaction also allows for error handling to remain a primary concern without it getting in the way of tidy, straightforward operation logic.
 

--- a/source/gems/dry-transaction/index.html.md
+++ b/source/gems/dry-transaction/index.html.md
@@ -37,7 +37,7 @@ class CreateUser
   include Dry::Transaction
 
   step :validate
-  step :persist
+  step :create
 
   private
 
@@ -45,7 +45,7 @@ class CreateUser
     # returns Success(valid_data) or Failure(validation)
   end
 
-  def persist(input)
+  def create(input)
     # returns Success(user)
   end
 end

--- a/source/gems/dry-transaction/injecting-operations.html.md
+++ b/source/gems/dry-transaction/injecting-operations.html.md
@@ -17,8 +17,8 @@ class CreateUser
   include Dry::Transaction(container: Container)
 
   step :prepare
-  step :validate, with: "operations.validate"
-  step :persist, with: "operations.persist"
+  step :validate, with: "users.validate"
+  step :create, with: "users.create"
 
   private
 
@@ -27,11 +27,11 @@ class CreateUser
   end
 end
 
-prepare = -> input { input.merge(name: "#{input[:name]}!!") }
-persist = -> user { Failure([:will_not_persist, user]) }
+prepare = -> input { Success(input.merge(name: "#{input[:name]}!!")) }
+create  = -> user  { Failure([:could_not_create, user]) }
 
-create_user = CreateUser.new(prepare: prepare, persist: persist)
+create_user = CreateUser.new(prepare: prepare, create: create)
 
 create_user.call(name: "Jane", email: "jane@doe.com")
-# => Failure([:will_not_persist, {:name => "Jane!!", :email => "jane@doe.com"})
+# => Failure([:could_not_create, {:name => "Jane!!", :email => "jane@doe.com"})
 ```

--- a/source/gems/dry-transaction/step-adapters.html.md
+++ b/source/gems/dry-transaction/step-adapters.html.md
@@ -19,6 +19,7 @@ class CreateUser
 
   map :process
   try :validate, catch: ValidationError
-  tee :persist
+  map :create
+  tee :notify
 end
 ```

--- a/source/gems/dry-transaction/step-notifications.html.md
+++ b/source/gems/dry-transaction/step-notifications.html.md
@@ -4,7 +4,7 @@ layout: gem-single
 name: dry-transaction
 ---
 
-As well as matching on the final transaction result, you can subscribe to individual steps and trigger specific behaviours based on their success or failure.
+As well as matching on the final transaction result, you can subscribe to individual steps and trigger specific behaviors based on their success or failure.
 
 You can subscribe to events from specific steps using `#subscribe(step_name: listener)`, or subscribe to all steps via `#subscribe(listener)`.
 

--- a/source/gems/dry-transaction/step-notifications.html.md
+++ b/source/gems/dry-transaction/step-notifications.html.md
@@ -20,40 +20,47 @@ For example:
 NOTIFICATIONS = []
 
 class CreateUser
-  include Dry::Transaction(container: Container)
+  include Dry::Transaction
 
-  step :process
   step :validate
-  step :persist
+  step :create
+
+  private
+
+  def validate(input)
+    # ...
+  end
+
+  def create(input)
+    # ...
+  end
 end
 
-module UserPersistListener
+module UserCreationListener
   extend self
 
   def on_step(event)
-    NOTIFICATIONS << "Started persistence of #{user[:email]}"
+    NOTIFICATIONS << "Started creation of #{user[:email]}"
   end
 
   def on_step_succeeded(event)
     user = event[:value]
-    NOTIFICATIONS << "#{user[:email]} persisted"
+    NOTIFICATIONS << "#{user[:email]} created"
   end
 
   def on_step_failure(event)
     user = event[:value]
-    NOTIFICATIONS << "#{user[:email]} failed to persist"
+    NOTIFICATIONS << "#{user[:email]} creation failed"
   end
 end
 
 create_user = CreateUser.new
+create_user.subscribe(create: UserCreationListener)
 
-input = {"name" => "Jane", "email" => "jane@doe.com"}
-
-create_user.subscribe(persist: UserPersistListener)
-create_user.with_step_args(validate: "doe.com").call(input)
+create_user.call(name: "Jane", email: "jane@doe.com")
 
 NOTIFICATIONS
-# => ["Started persistence of jane@doe.com", "jane@doe.com persisted"]
+# => ["Started creation of jane@doe.com", "jane@doe.com created"]
 ```
 
 This pub/sub mechanism is provided by [dry-events](/gems/dry-events).

--- a/source/gems/dry-transaction/wrapping-operations.html.md
+++ b/source/gems/dry-transaction/wrapping-operations.html.md
@@ -13,7 +13,7 @@ class CreateUser
   include Dry::Transaction(container: Container)
 
   step :validate, with: "users.validate"
-  step :persist, with: "users.persist"
+  step :create, with: "users.create"
 
   private
 

--- a/source/gems/dry-transaction/wrapping-operations.html.md
+++ b/source/gems/dry-transaction/wrapping-operations.html.md
@@ -12,11 +12,12 @@ To wrap an operation, define an instance method with the same name as a step, an
 class CreateUser
   include Dry::Transaction(container: Container)
 
-  step :process, with: "operations.process"
+  step :validate, with: "users.validate"
+  step :persist, with: "users.persist"
 
   private
 
-  def process(input)
+  def validate(input)
     adjusted_input = upcase_values(input)
     super(adjusted_input)
   end
@@ -29,6 +30,6 @@ class CreateUser
 end
 
 create_user = CreateUser.new
-create_user.call("name" => "Jane", "email" => "jane@doe.com")
-# => Success({:name=>"JANE", :email=>"JANE@DOE.COM"})
+create_user.call(name: "Jane", email: "jane@doe.com")
+# => Success(#<User name="JANE" email="JANE@DOE.COM">)
 ```


### PR DESCRIPTION
To prepare for the release of the dry-transaction injection adjustments in https://github.com/dry-rb/dry-transaction/pull/109, I wanted to make sure the operation injection options were clear in the documentation. I've done this here, in https://github.com/dry-rb/dry-rb.org/commit/b9d3a1617abd40270c2349f75486616cc18bd3e8.

@GustavoCaso, @flash-gordon, let me know if this feels sufficient to you :)

Along with this change, I've spruced up a bunch of stuff across the dry-transaction in general:

- Added a code example of a transaction to the intro page. This was very wordy before. Now at least someone can just "skip to the code" if they want too :)
- Simplified code examples in general: use 2-step transactions only, and replace any operation implementation details with simple comments explaining the expected return values
- Provided a better (IMO) example of how to use `#with_step_args`
- Noted that we'll check for operations in containers using `#key?`