### PR TITLE
Advanced example of validating array of hashes

### DIFF
--- a/source/gems/dry-validation/array-as-input.html.md
+++ b/source/gems/dry-validation/array-as-input.html.md
@@ -7,7 +7,7 @@ name: dry-validation
 A schema can accept either a hash or an array as the input. If you want to define a schema for an array, simply use `each`:
 
 ``` ruby
-schema = Dry::Validation.Schema do
+my_schema = Dry::Validation.Schema do
   each do
     schema do
       required(:name).filled(:str?)
@@ -16,6 +16,6 @@ schema = Dry::Validation.Schema do
   end
 end
 
-schema.([{ name: 'Jane', age: 21 }, { name: 'Joe', age: nil }]).messages
+my_schema.([{ name: 'Jane', age: 21 }, { name: 'Joe', age: nil }]).messages
 # { 1 => { age: ['must be filled'] } }
 ```


### PR DESCRIPTION
Advanced example of validating array of hashes. Also changing names of variables that the schemas are bound to to avoid clashing with the `schema` method name in the context of a predicate block.