### PR TITLE
Hotfix version switcher

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -326,7 +326,7 @@ helpers do
     version = extract_version(url)
 
     if version
-      url.gsub(VERSION_REGEX, new_version)
+      url.gsub(VERSION_REGEX, "#{new_version}/")
     else
       parts = url.split('/')
 

--- a/data/versions.yaml
+++ b/data/versions.yaml
@@ -1,7 +1,6 @@
 dry-monads:
   versions:
     - "0.4"
-    - code: "1.0"
-      name: "1.0"
+    - "1.0"
   current: "1.0"
   fallback: "1.0"

--- a/source/partials/_version_switcher.slim
+++ b/source/partials/_version_switcher.slim
@@ -3,5 +3,5 @@
     'Version:
     select#sidebar__version-switcher
       - version_variants.each do |code:, name:|
-        option value="#{ set_version(page.url, code) }" selected=("selected" if versions_match?(code, version))
+        option value="/gems/#{page.name}/#{code}" selected=("selected" if versions_match?(code, version))
           = name


### PR DESCRIPTION
Malformed switcher URL causes 404 error

* Go to http://dry-rb.org/gems/dry-monads/1.0/result/
* Switch version
* 404

Won't happen if you visit http://dry-rb.org/gems/dry-monads/result/

As an addition to the fix, I've changed switcher behavior. Now instead of switching to an older version of the page (and potentially getting a 404), version switcher always redirects to index page (`gems/dry-monads/0.4/result` → `gems/dry-monads/1.0`). 

Having to navigate back the the same page may not be convenient, but the solution helps reduce dead links. 

I think we could add a more complex logic later