### PR TITLE
Add CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@
 
 # some npm cache stuff, I suppose
 source/**/.!*
+
+.rvmrc
+.ruby-version
+.ruby-gemset

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: ruby
+sudo: false
+install:
+  - bundle install --without development --jobs=3 --retry=3
+  - yarn
+cache:
+  - bundler
+  - yarn
+branches:
+  only:
+  - master
+script:
+- bundle exec middleman build
+deploy:
+  fqdn: dry-rb.org
+  local_dir: docs
+  provider: pages
+  skip-cleanup: true
+  github-token: $GITHUB_TOKEN
+  keep-history: false
+  target-branch: gh-pages
+  on:
+    branch: master


### PR DESCRIPTION
Addresses #98 

Adds Travis CI as a tool to build and deploy website

* Only builds `master`
* Builds and pushes the build to `gh-pages` branch

How to set up:

* Merge to master
* [Get a personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/)
* Set up Travis and add the personal access token as an environment variable: `GITHUB_TOKEN`
* Configure GH Pages to only deploy from `gh-pages` branch