### PR TITLE
dry-validation: add documentation for extensions

### DIFF
--- a/source/gems/dry-validation/extensions.html.md
+++ b/source/gems/dry-validation/extensions.html.md
@@ -7,7 +7,7 @@ sections:
   - struct
 ---
 
-`dry-validation` can be extended with extension. Those extensions are loading with `Dry::Validation.load_extensions`.
+`dry-validation` can be extended with extension. Those extensions are loaded with `Dry::Validation.load_extensions`.
 
 Extensions available:
 

--- a/source/gems/dry-validation/extensions.html.md
+++ b/source/gems/dry-validation/extensions.html.md
@@ -4,6 +4,7 @@ layout: gem-single
 name: dry-validation
 sections:
   - monads
+  - struct
 ---
 
 `dry-validation` can be extended with extension. Those extensions are loading with `Dry::Validation.load_extensions`.
@@ -11,3 +12,4 @@ sections:
 Extensions available:
 
   * [Monads](/gems/dry-validation/extensions/monads)
+  * [Struct](/gems/dry-validation/extensions/struct)

--- a/source/gems/dry-validation/extensions.html.md
+++ b/source/gems/dry-validation/extensions.html.md
@@ -1,0 +1,13 @@
+---
+title: Extensions
+layout: gem-single
+name: dry-validation
+sections:
+  - monads
+---
+
+`dry-validation` can be extended with extension. Those extensions are loading with `Dry::Validation.load_extensions`.
+
+Extensions available:
+
+  * [Monads](/gems/dry-validation/extensions/monads)

--- a/source/gems/dry-validation/extensions/monads.html.md
+++ b/source/gems/dry-validation/extensions/monads.html.md
@@ -1,0 +1,9 @@
+---
+title: Monads
+layout: gem-single
+name: dry-validation
+---
+
+This extension add a new method (`#to_monad`) to your schema.
+
+This is useful when used with `dry-monads` and the [`do` notation](/gems/dry-monads/do-notation/).

--- a/source/gems/dry-validation/extensions/monads.html.md
+++ b/source/gems/dry-validation/extensions/monads.html.md
@@ -6,4 +6,10 @@ name: dry-validation
 
 This extension add a new method (`#to_monad`) to your schema.
 
-This is useful when used with `dry-monads` and the [`do` notation](/gems/dry-monads/do-notation/).
+```ruby
+schema = Dry::Validation.Schema { required(:name).filled(:str?, size?: 2..4) }
+schema.call(name: 'Jane').to_either # => Dry::Monads::Success({ name: 'Jane' })
+schema.call(name: '').to_either     # => Dry::Monads::Failure(name: ['name must be filled', 'name length must be within 2 - 4'])
+```
+
+This can be useful when used with `dry-monads` and the [`do` notation](/gems/dry-monads/do-notation/).

--- a/source/gems/dry-validation/extensions/struct.html.md
+++ b/source/gems/dry-validation/extensions/struct.html.md
@@ -1,0 +1,24 @@
+---
+title: Struct
+layout: gem-single
+name: dry-validation
+---
+
+This extension allows schema to use `dry-struct`
+
+``` ruby
+class Name < Dry::Struct::Value
+  attribute :given_name, Dry::Types['strict.string']
+  attribute :family_name, Dry::Types['strict.string']
+end
+
+class Person < Dry::Struct::Value
+  attribute :name, Name
+end
+
+Dry::Validation.Schema do
+  required(:person).filled(Person)
+end
+```
+
+As shown in the previous example, it also works with nested struct.

--- a/source/gems/dry-validation/index.html.md
+++ b/source/gems/dry-validation/index.html.md
@@ -18,6 +18,7 @@ sections:
   - input-preprocessing
   - error-messages
   - comparison-with-activemodel
+  - extensions
 ---
 
 Unlike other, well known, validation solutions in Ruby, `dry-validation` takes a different approach and focuses a lot on explicitness, clarity and precision of validation logic. It is designed to work with any data input, whether it's a simple hash, an array or a complex object with deeply nested data.


### PR DESCRIPTION
I was thinking about adding example(s) but I'm not sure it's the right place to do it, as I'll need to talk about other gems (`dry-monads`)

closes #258 