### PR TITLE
Prepend missing module to result monads

### DIFF
--- a/source/gems/dry-monads/1.0/result.html.md
+++ b/source/gems/dry-monads/1.0/result.html.md
@@ -83,9 +83,9 @@ class AssociateUser
     user = User.find(id)
 
     if user
-      Success(user)
+      M.Success(user)
     else
-      Failure(:user_not_found)
+      M.Failure(:user_not_found)
     end
   end
 
@@ -93,9 +93,9 @@ class AssociateUser
     address = Address.find(id)
 
     if address
-      Success(address)
+      M.Success(address)
     else
-      Failure(:address_not_found)
+      M.Failure(:address_not_found)
     end
   end
 end


### PR DESCRIPTION
### Description

Added the `M` module before calling `Success` and `Failure` where it was missing.