### PR TITLE
Fix typo in code example

### DIFF
--- a/source/gems/dry-transaction/step-notifications.html.md
+++ b/source/gems/dry-transaction/step-notifications.html.md
@@ -40,6 +40,7 @@ module UserCreationListener
   extend self
 
   def on_step(event)
+    user = event[:value]
     NOTIFICATIONS << "Started creation of #{user[:email]}"
   end
 


### PR DESCRIPTION
Fixes typo in code example for dry-transaction steps, identified in dry-rb/dry-transaction#110 