### PR TITLE
add one more argument to dry-core-cache

### DIFF
--- a/source/gems/dry-core/index.html.md
+++ b/source/gems/dry-core/index.html.md
@@ -27,7 +27,7 @@ class Foo
   end
 
   def heavy_computation(arg1, arg2)
-    fetch_or_store(source, arg1, arg2) { arg1 ^ arg2 }
+    fetch_or_store(source, arg1, arg2) { source ^ arg1 ^ arg2 }
   end
 end
 ```

--- a/source/gems/dry-core/index.html.md
+++ b/source/gems/dry-core/index.html.md
@@ -20,8 +20,14 @@ require 'dry/core/cache'
 class Foo
   extend Dry::Core::Cache
 
+  attr_reader :source
+
+  def initialize(source)
+    @source = source
+  end
+
   def heavy_computation(arg1, arg2)
-    fetch_or_store(arg1, arg2) { arg1 ^ arg2 }
+    fetch_or_store(source, arg1, arg2) { arg1 ^ arg2 }
   end
 end
 ```


### PR DESCRIPTION
@timriley @solnic while working on the performance improvements for `dry-view` I wanted to use `dry-core/cache` but based on the example it was clear **to me** that we could pass other arguments that the ones to the method. In the example `args1` and `args2`

So I decided to add this little extra. Of course, the miss interpretation was main so if you think is not useful, please just let me know and I will close the PR 