### PR TITLE
Adds z-index to menu dropdown

### DIFF
--- a/assets/stylesheets/site.css.scss
+++ b/assets/stylesheets/site.css.scss
@@ -859,6 +859,7 @@ pre code {
   margin-left: -25px;
   text-align: left;
   left: 0;
+  z-index: 1;
   @include mobile {
     display: none !important;
   }


### PR DESCRIPTION
👋 There's been a tiny bug with the menu of this site. On certain pages, the content clashes with the gem dropdown. 😅

<img width="361" alt="screen shot 2019-02-07 at 10 11 11 pm" src="https://user-images.githubusercontent.com/3144140/52458681-7436a280-2b26-11e9-8145-ebff091fe913.png">

So I introduce my ginormous contribution to dry-rb. :trollface: 

For reals, though. Let me know if I'm missing a step here. As always, thanks for all the work on dry-rb. ❤️ 