### PR TITLE
dry-initializer: terminology: method "reloading" -> overriding

### DIFF
--- a/source/gems/dry-initializer/attributes.html.md
+++ b/source/gems/dry-initializer/attributes.html.md
@@ -55,7 +55,7 @@ Notice that `public_attribute` reads *public reader methods*, not variables. Tha
 
 Another difference concerns unassigned values. Because the reader `user.email` returns `nil` (its `@email` variable contains `Dry::Initializer::UNDEFINED` constant), the `public_attributes` adds this value to the hash using the method.
 
-The third thing to mention is that you can reload the reader, and it is the reloaded method will be used by `public_attributes`:
+The third thing to mention is that you can override the reader, and it is the overriden method which will be used by `public_attributes`:
 
 ```ruby
 require 'dry-initializer'

--- a/source/gems/dry-initializer/inheritance.html.md
+++ b/source/gems/dry-initializer/inheritance.html.md
@@ -26,8 +26,8 @@ employee.position # => 'supercargo'
 employee = Employee.new # => fails because type
 ```
 
-You can reload params and options.
-Such a reloading leaves initial order of params (positional arguments) unchanged:
+You can override params and options.
+Such overriding leaves initial order of params (positional arguments) unchanged:
 
 ```ruby
 class Employee < User


### PR DESCRIPTION
I would like to propose a small change to the terminology. It may also be correct to speak of "method reloading" in context of class inheritance (I vaguely remember having already seen it, presumably in older literature), but I'm definitely more accustomed to read of "method _overriding_". Since "overriding" is already frequently mentioned throughout the dry-rb docs and "reloading" only appears in these two pages, a change unifying the terminology seems to be reasonable.