### PR TITLE
CI: remove unused option sudo: false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: false
 install:
   - bundle install --without development --jobs=3 --retry=3
   - yarn


### PR DESCRIPTION
  - Removes an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration