### PR TITLE
Add the missing link to `type-specs` page

### DIFF
--- a/source/gems/dry-validation/0.13/index.html.md
+++ b/source/gems/dry-validation/0.13/index.html.md
@@ -16,6 +16,7 @@ sections:
   - custom-validation-blocks
   - dynamic-predicate-arguments
   - input-preprocessing
+  - type-specs
   - error-messages
   - comparison-with-activemodel
   - extensions


### PR DESCRIPTION
Reopen #293 