### PR TITLE
[dry-validation] add `key.failure` to match v1.0.0.beta2 syntax

### DIFF
--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -2,7 +2,7 @@
   desc: Powerful data validation
   versions:
     - code: "1.0.0"
-      name: "1.0.0.alpha1"
+      name: "1.0.0.beta2"
     - "0.13"
   current_version: "0.13"
   fallback_version: "0.13"

--- a/source/gems/dry-validation/1.0.0/index.html.md
+++ b/source/gems/dry-validation/1.0.0/index.html.md
@@ -24,11 +24,11 @@ class NewUserContract < Dry::Validation::Contract
   end
 
   rule(:email) do
-    failure('is already taken') if User.where(email: values[:email]).count > 0
+    key.failure('is already taken') if User.where(email: values[:email]).count > 0
   end
 
   rule(:age) do
-    failure('must be greater than 18') if values[:age] < 18
+    key.failure('must be greater than 18') if values[:age] < 18
   end
 end
 


### PR DESCRIPTION
I'm working on updating some code from `dry-validation v0.12` to the current version. I thought I may as well update docs as I go along.

This updates the hosted doc version to v1.0.0.beta2 and adds the `key.` before `failure` that did not exist in `v1.0.0.alpha`.