### PR TITLE
dry-schema: fix example on the "Basics" page

### DIFF
--- a/source/gems/dry-schema/basics.html.md
+++ b/source/gems/dry-schema/basics.html.md
@@ -26,13 +26,11 @@ schema = Dry::Schema.Params do
   required(:age).filled(:integer, gt?: 18)
 end
 
-errors = schema.call(email: 'jane@doe.org', age: 19).messages
-
-puts errors.inspect
-# []
+schema.call(email: 'jane@doe.org', age: 19)
+# #<Dry::Schema::Result{:email=>"jane@doe.org", :age=>19} errors={}>
 
 schema.call("email" => "", "age" => "19")
-# #<Dry::Schema::Result{:email=>nil, :age=>19} errors={:email=>["must be filled"]}>
+# #<Dry::Schema::Result{:email=>"", :age=>19} errors={:email=>["must be filled"]}>
 ```
 
 When you apply this schema to an input, 3 things happen:


### PR DESCRIPTION
The example shows calling `#messages` on the `Dry::Schema::Result` object, but that method isn't defined in version 1.0.0. So I just chose to show the whole `Dry::Schema::Result` object, like we do in the next line.

While here, I also noticed that an empty string remains the same, it doesn't get coerced into `nil`. 