### PR TITLE
Fix dry-validation example on the main page.

### DIFF
--- a/source/index.html.slim
+++ b/source/index.html.slim
@@ -22,7 +22,7 @@ title: Home
                 class NewUserContract < Dry::Validation::Contract
                   params do
                     required(:name).filled(:string)
-                    required(:age).filled(:string)
+                    required(:age).filled(:integer)
                   end
 
                   rule(:age) { key.failure("must be greater than 18") if value < 18 }
@@ -30,9 +30,11 @@ title: Home
 
                 contract = NewUserContract.new
 
-                contract.("name" => "Jane", "age" => "30").errors.to_h
-                # => {name: "Jane", age: 30}
+                contract.("name" => "Jane", "age" => "30").success?
+                # => true
 
+                contract.("name" => "Jane", "age" => "17").failure?
+                # => true
                 contract.("name" => "Jane", "age" => "17").errors.to_h
                 # => {:age=>["must be greater than 18"]}
                 ```


### PR DESCRIPTION
Hi 👋🏻

I found an invalid `dry-validation` example on the main page and have tried to fix it :)

I have tried to make this example more clear and readable by using method `#success?` and `#failure?` but we can keep this example `as is` with an explanation through the contract`s `errors` object.

