### PR TITLE
Use .boot instead of deprecated .finalize

### DIFF
--- a/source/gems/dry-system/auto-import.html.md
+++ b/source/gems/dry-system/auto-import.html.md
@@ -69,7 +69,7 @@ require_relative 'container'
 Import = Application.injector
 
 # system/boot/persistence.rb
-Application.finalize(:persistence) do |container|
+Application.boot(:persistence) do |container|
   start do
     require 'sequel'
     container.register('persistence.db', Sequel.connect(ENV['DB_URL']))


### PR DESCRIPTION
`.finalize` has been deprecated in favour of `.boot`, but docs still use it. I get this message in dry-system 0.11 while using example code from docs:

```
[Dry::System::Container] #finalize is deprecated and will be removed in the next major version
Please use #boot instead.
```