### PR TITLE
Fix: add sticky footer

### DIFF
--- a/assets/stylesheets/site.css.scss
+++ b/assets/stylesheets/site.css.scss
@@ -70,6 +70,15 @@ body {
   and (max-width: 900px) {
     font-size: 15px;
   }
+
+  // sticky footer
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
+}
+
+main {
+  flex: 1;
 }
 
 .article-list {

--- a/source/layouts/base.slim
+++ b/source/layouts/base.slim
@@ -3,5 +3,6 @@ html lang="en"
   head = partial("head")
   body
     = partial "header-home"
-    = yield
+    main
+      = yield
     = partial "footer"

--- a/source/layouts/content-page-wide.slim
+++ b/source/layouts/content-page-wide.slim
@@ -3,8 +3,9 @@ html lang="en"
   head = partial("head")
   body
     = partial "header-listing"
-    .row
-      .content-wrap
-        article.content-article.content-article-wide
-          = yield
+    main
+      .row
+        .content-wrap
+          article.content-article.content-article-wide
+            = yield
     = partial "footer"

--- a/source/layouts/content-page.slim
+++ b/source/layouts/content-page.slim
@@ -3,8 +3,9 @@ html lang="en"
   head = partial("head")
   body
     = partial "header-listing"
-    .row
-      .content-wrap
-        article.content-article
-          = yield
+    main
+      .row
+        .content-wrap
+          article.content-article
+            = yield
     = partial "footer"

--- a/source/layouts/gem-single.slim
+++ b/source/layouts/gem-single.slim
@@ -3,12 +3,18 @@ html lang="en"
   head = partial("head")
   body
     = partial "header"
-    .row
-      .content-wrap
-        aside.sidebar
-          = partial "version_switcher"
-          == nav
-        article.gem-article
-          h2 = page.data.title
-          = yield
+    main
+      .intro-page
+        .content-wrap
+          .intro-page__inner
+            h1.intro-page__header == page_header
+            p.intro-page__link == github_link
+      .row
+        .content-wrap
+          aside.sidebar
+            = partial "version_switcher"
+            == nav
+          article.gem-article
+            h2 = page.data.title
+            = yield
     = partial "footer"

--- a/source/layouts/listing.slim
+++ b/source/layouts/listing.slim
@@ -3,8 +3,9 @@ html lang="en"
   head = partial("head")
   body
     = partial "header-listing"
-    .row
-      .content-wrap
-        .article-list
-          = yield
+    main
+      .row
+        .content-wrap
+          .article-list
+            = yield
     = partial "footer"

--- a/source/layouts/news-index.html.slim
+++ b/source/layouts/news-index.html.slim
@@ -3,7 +3,25 @@ html lang="en"
   head = partial "head"
   body
     = partial "header-news-index"
-    .row
-      .content-wrap
-        = yield
+    main
+      .intro-page
+        .content-wrap
+          .intro-page__inner
+            - if paginate && num_pages > 1
+              .news-pagination
+                ' Page
+                => page_number
+                ' of
+                = num_pages
+                span.news-pagination__links
+                  - if prev_page
+                    = link_to '&larr; Prev', prev_page
+                  - if next_page
+                    = link_to 'Next &rarr;', next_page
+
+            h1
+              a href="/news" == page.data.title
+      .row
+        .content-wrap
+          = yield
     = partial "footer"

--- a/source/layouts/news-single.slim
+++ b/source/layouts/news-single.slim
@@ -3,8 +3,9 @@ html lang="en"
   head = partial("head")
   body
     = partial "header-news"
-    .row
-      .content-wrap
-        article.news-article
-          = yield
+    main
+      .row
+        .content-wrap
+          article.news-article
+            = yield
     = partial "footer"

--- a/source/partials/_header-listing.slim
+++ b/source/partials/_header-listing.slim
@@ -1,8 +1,8 @@
 header
- .content-wrap
-   = partial "nav"
+  .content-wrap
+    = partial "nav"
 - if page.data.title
   .intro-page
-   .content-wrap
-    .intro-page__inner
-      h1 == page.data.title
+    .content-wrap
+      .intro-page__inner
+        h1 == page.data.title

--- a/source/partials/_header-news-index.html.slim
+++ b/source/partials/_header-news-index.html.slim
@@ -1,20 +1,3 @@
 header
   .content-wrap
     = partial "nav"
-.intro-page
-  .content-wrap
-    .intro-page__inner
-      - if paginate && num_pages > 1
-        .news-pagination
-          ' Page
-          => page_number
-          ' of
-          = num_pages
-          span.news-pagination__links
-            - if prev_page
-              = link_to '&larr; Prev', prev_page
-            - if next_page
-              = link_to 'Next &rarr;', next_page
-
-      h1
-        a href="/news" == page.data.title

--- a/source/partials/_header-news.slim
+++ b/source/partials/_header-news.slim
@@ -1,11 +1,11 @@
 header
- .content-wrap
-   = partial "nav"
+  .content-wrap
+    = partial "nav"
 - if page.data.title
   .intro-page.intro-page--content
     .content-wrap
       .intro-page__inner
-         h1 == page.data.title
-         - if page.data.author
-           .news-article-meta
-             = "Published on #{I18n.l(current_page.data.date, format: :long)} by #{author_url}"
+        h1 == page.data.title
+        - if page.data.author
+          .news-article-meta
+            = "Published on #{I18n.l(current_page.data.date, format: :long)} by #{author_url}"

--- a/source/partials/_header.slim
+++ b/source/partials/_header.slim
@@ -1,8 +1,3 @@
 header
- .content-wrap
-   = partial "nav"
-.intro-page
- .content-wrap
-  .intro-page__inner
-    h1.intro-page__header == page_header
-    p.intro-page__link == github_link
+  .content-wrap
+    = partial "nav"


### PR DESCRIPTION
On pages with less content footer wasn't stick to bottom. This PR fixes it.

Closes [#13](https://github.com/dry-rb/dry-rb.org/issues/13)