### PR TITLE
Add docs about `predicates_as_macros` extension

### DIFF
--- a/source/gems/dry-validation/1.0/extensions.html.md
+++ b/source/gems/dry-validation/1.0/extensions.html.md
@@ -32,3 +32,34 @@ my_contract.(name: "")
   .fmap { |r| puts "passed: #{r.to_h.inspect}" }
   .or   { |r| puts "failed: #{r.errors.to_h.inspect}" }
 ```
+
+### Predicates as macros
+
+This extension makes [`dry-logic`
+predicates](https://dry-rb.org/gems/dry-logic/1.0/predicates/) which
+are concerned with data values (in opposition with types) available as
+macros for validation rules.
+
+Besides enabling the extension, you have to call
+`import_predicates_as_macros` before being able to use them:
+
+```ruby
+require 'dry/validation'
+
+Dry::Validation.load_extensions(:predicates_as_macros)
+
+class ApplicationContract < Dry::Validation::Contract
+  import_predicates_as_macros
+end
+
+class AgeContract < ApplicationContract
+  schema do
+    required(:age).filled(:integer)
+  end
+
+  rule(:age).validate(gteq?: 18)
+end
+
+AgeContract.new.(age: 17).errors.first.text
+# => 'must be greater than or equal to 18'
+```


### PR DESCRIPTION
I think it is not still released, but this PR leaves the documentation ready.