### PR TITLE
Fix typo on rules documentation

### DIFF
--- a/source/gems/dry-validation/1.0/rules.html.md
+++ b/source/gems/dry-validation/1.0/rules.html.md
@@ -56,7 +56,7 @@ class EventContract < Dry::Validation::Contract
   end
 
   rule(:end_date, :start_date) do
-    key.failure('must be after start date') if values[:end_date] >= values[:start_date]
+    key.failure('must be after start date') if values[:end_date] < values[:start_date]
   end
 end
 


### PR DESCRIPTION
The rule block was stating the failure if end_date is greater than start_date.