### PR TITLE
Add link to dry-rb.org to the footer

### DIFF
--- a/source/partials/_footer.html.slim
+++ b/source/partials/_footer.html.slim
@@ -26,3 +26,8 @@ footer
         ' Website made with love by
         a href="https://www.icelab.com.au/" Icelab
         | .
+    .footer__credits
+      p
+        'Found a typo? Want to add something? <br />Send us an issue or a pull-request at
+        a href="https://github.com/dry-rb/dry-rb.org/" GitHub
+        | .


### PR DESCRIPTION
The comment by @JoshTGreenwood in https://github.com/dry-rb/dry-rb.org/issues/270#issuecomment-524510081 got me thinking about adding a tiny note to invite more contributors.

It looks pretty simple, but might reduce the frustration.

<img width="760" alt="the note" src="https://user-images.githubusercontent.com/887264/63636274-f4ad9280-c675-11e9-9824-fff8eadfe9a6.png">
