### PR TITLE
Change structure of dry/core documentation

### DIFF
--- a/source/gems/dry-core/cache.html.md
+++ b/source/gems/dry-core/cache.html.md
@@ -1,0 +1,31 @@
+---
+title: Cache
+layout: gem-single
+name: dry-core
+---
+
+Allows you to cache call results that are solely determined by arguments.
+
+```ruby
+require 'dry/core/cache'
+
+class Foo
+  extend Dry::Core::Cache
+
+  attr_reader :source
+
+  def initialize(source)
+    @source = source
+  end
+
+  def heavy_computation(arg1, arg2)
+    fetch_or_store(source, arg1, arg2) { source ^ arg1 ^ arg2 }
+  end
+end
+```
+
+### Note
+
+Beware Proc instance hashes are not equal, i.e. `-> { 1 }.hash != -> { 1 }.hash`.
+This means you shouldn't pass Procs in args unless you're sure they are always the same instances, otherwise you introduce a memory leak
+

--- a/source/gems/dry-core/classes.html.md
+++ b/source/gems/dry-core/classes.html.md
@@ -1,0 +1,14 @@
+---
+title: Working with Classes
+layout: gem-single
+name: dry-core
+sections:
+ - class-attributes
+ - class-builder
+---
+
+You can enhance your classes using the [Class Attributes][class-attributes] or eliminate extra boilerplate using the [Class Builder][class-builder]
+
+
+[class-attributes]: /gems/dry-core/classes/class-attributes
+[class-builder]: /gems/dry-core/classes/class-builder

--- a/source/gems/dry-core/classes/class-attributes.html.md
+++ b/source/gems/dry-core/classes/class-attributes.html.md
@@ -1,0 +1,47 @@
+---
+title: Class Attributes
+layout: gem-single
+name: dry-core
+---
+
+```ruby
+require 'dry/core/class_attributes'
+
+class ExtraClass
+  extend Dry::Core::ClassAttributes
+
+  defines :hello
+
+  hello 'world'
+end
+
+# example with inheritance and type checking
+# setting up an invalid value will raise Dry::Core::InvalidClassAttributeValue
+
+class MyClass
+  extend Dry::Core::ClassAttributes
+
+  defines :one, :two, type: Integer
+
+  one 1
+  two 2
+end
+
+class OtherClass < MyClass
+  two 3
+end
+
+MyClass.one # => 1
+MyClass.two # => 2
+
+OtherClass.one # => 1
+OtherClass.two # => 3
+
+# example type checking with dry-types
+
+class Foo
+  extend Dry::Core::ClassAttributes
+
+  defines :one, :two, type: Dry::Types['strict.integer']
+end
+```

--- a/source/gems/dry-core/classes/class-builder.html.md
+++ b/source/gems/dry-core/classes/class-builder.html.md
@@ -1,0 +1,14 @@
+---
+title: Class Builder
+layout: gem-single
+name: dry-core
+---
+
+```ruby
+require 'dry/core/class_builder'
+
+builder = Dry::Core::ClassBuilder.new(name: 'MyClass')
+
+klass = builder.call
+klass.name # => "MyClass"
+```

--- a/source/gems/dry-core/constants.html.md
+++ b/source/gems/dry-core/constants.html.md
@@ -1,0 +1,15 @@
+---
+title: Constants
+layout: gem-single
+name: dry-core
+---
+
+A list of constants you can use to avoid memory allocations or identity checks.
+
+* `EMPTY_ARRAY`
+* `EMPTY_HASH`
+* `EMPTY_OPTS`
+* `EMPTY_SET`
+* `EMPTY_STRING`
+* `Undefined` - A special value you can use as a default to know if no arguments were passed to you method
+

--- a/source/gems/dry-core/deprecations.html.md
+++ b/source/gems/dry-core/deprecations.html.md
@@ -1,0 +1,35 @@
+---
+title: Deprecations
+layout: gem-single
+name: dry-core
+---
+
+For deprecate ruby methods you need to extend `Dry::Core::Deprecations` module with a tag that will be displayed in the output. For example:
+
+```ruby
+require 'dry/core/deprecations'
+
+class Foo
+  extend Dry::Core::Deprecations[:tag]
+
+  def self.old_class_api; end
+  def self.new_class_api; end
+
+  deprecate_class_method :old_class_api, :new_class_api
+
+  def old_api; end
+  def new_api; end
+
+  deprecate :old_api, :new_api
+end
+
+Foo.old_class_api
+# => [tag] Foo.old_class_api is deprecated and will be removed in the next major version
+# => Please use Foo.new_class_api instead.
+# => file.rb:9:in `<class:Foo>'
+
+Foo.new.old_api
+# => [tag] Foo#old_api is deprecated and will be removed in the next major version
+# => Please use Foo#new_api instead.
+# => file.rb:14:in `<class:Foo>'
+```

--- a/source/gems/dry-core/extensions.html.md
+++ b/source/gems/dry-core/extensions.html.md
@@ -1,0 +1,23 @@
+---
+title: Extensions
+layout: gem-single
+name: dry-core
+---
+
+Define extensions that can be later enabled by the user.
+
+```ruby
+require 'dry/core/extensions'
+
+class Foo
+  extend Dry::Core::Extensions
+
+  register_extension(:bar) do
+     def bar; :bar end
+  end
+end
+
+Foo.new.bar # => NoMethodError
+Foo.load_extensions(:bar)
+Foo.new.bar # => :bar
+```

--- a/source/gems/dry-core/index.html.md
+++ b/source/gems/dry-core/index.html.md
@@ -1,155 +1,33 @@
 ---
-title: Introduction &amp; Usage
+title: Introduction
 description: A toolset of small support modules used throughout the @dry-rb & @rom-rb ecosystems
 layout: gem-single
 order: 5
 type: gem
 name: dry-core
+sections:
+ - cache
+ - constants
+ - classes
+ - deprecations
+ - extensions
 ---
 
 `dry-core` is a simple toolset that can be used in many places.
 
-## Usage
+## Features
 
-### Cache
-Allows you to cache call results that are solely determined by arguments.
+- [Cache][cache]: Allows you to cache call results that are solely determined by arguments
+- [Class Attributes][class-attributes]
+- [Class Builder][class-builder]
+- [Constants][constants]: A list of constants you can use to avoid memory allocations or identity checks.
+- [Deprecations][deprecations]
+- [Extensions][extensions]
 
-```ruby
-require 'dry/core/cache'
 
-class Foo
-  extend Dry::Core::Cache
-
-  attr_reader :source
-
-  def initialize(source)
-    @source = source
-  end
-
-  def heavy_computation(arg1, arg2)
-    fetch_or_store(source, arg1, arg2) { source ^ arg1 ^ arg2 }
-  end
-end
-```
-
-### Note
-
-Beware Proc instance hashes are not equal, i.e. `-> { 1 }.hash != -> { 1 }.hash`.
-This means you shouldn't pass Procs in args unless you're sure they are always the same instances, otherwise you introduce a memory leak
-
-### Class Attributes
-
-```ruby
-require 'dry/core/class_attributes'
-
-class ExtraClass
-  extend Dry::Core::ClassAttributes
-
-  defines :hello
-
-  hello 'world'
-end
-
-# example with inheritance and type checking
-# setting up an invalid value will raise Dry::Core::InvalidClassAttributeValue
-
-class MyClass
-  extend Dry::Core::ClassAttributes
-
-  defines :one, :two, type: Integer
-
-  one 1
-  two 2
-end
-
-class OtherClass < MyClass
-  two 3
-end
-
-MyClass.one # => 1
-MyClass.two # => 2
-
-OtherClass.one # => 1
-OtherClass.two # => 3
-
-# example type checking with dry-types
-
-class Foo
-  extend Dry::Core::ClassAttributes
-
-  defines :one, :two, type: Dry::Types['strict.integer']
-end
-```
-
-### Class Builder
-
-```ruby
-require 'dry/core/class_builder'
-
-builder = Dry::Core::ClassBuilder.new(name: 'MyClass')
-
-klass = builder.call
-klass.name # => "MyClass"
-```
-
-### Constants
-A list of constants you can use to avoid memory allocations or identity checks.
-
-* `EMPTY_ARRAY`
-* `EMPTY_HASH`
-* `EMPTY_OPTS`
-* `EMPTY_SET`
-* `EMPTY_STRING`
-* `Undefined` - A special value you can use as a default to know if no arguments were passed to you method
-
-### Deprecations
-
-For deprecate ruby methods you need to extend `Dry::Core::Deprecations` module
-with a tag that will be displayed in the output. For example:
-
-```ruby
-require 'dry/core/deprecations'
-
-class Foo
-  extend Dry::Core::Deprecations[:tag]
-
-  def self.old_class_api; end
-  def self.new_class_api; end
-
-  deprecate_class_method :old_class_api, :new_class_api
-
-  def old_api; end
-  def new_api; end
-
-  deprecate :old_api, :new_api
-end
-
-Foo.old_class_api
-# => [tag] Foo.old_class_api is deprecated and will be removed in the next major version
-# => Please use Foo.new_class_api instead.
-# => file.rb:9:in `<class:Foo>'
-
-Foo.new.old_api
-# => [tag] Foo#old_api is deprecated and will be removed in the next major version
-# => Please use Foo#new_api instead.
-# => file.rb:14:in `<class:Foo>'
-```
-
-### Extensions
-Define extensions that can be later enabled by the user.
-
-```ruby
-require 'dry/core/extensions'
-
-class Foo
-  extend Dry::Core::Extensions
-
-  register_extension(:bar) do
-     def bar; :bar end
-  end
-end
-
-Foo.new.bar # => NoMethodError
-Foo.load_extensions(:bar)
-Foo.new.bar # => :bar
-```
+[cache]: /gems/dry-core/cache
+[class-attributes]: /gems/dry-core/classes/class-attributes
+[class-builder]: /gems/dry-core/classes/class-builder
+[constants]: /gems/dry-core/constants
+[extensions]: /gems/dry-core/extensions
+[deprecations]: /gems/dry-core/deprecations


### PR DESCRIPTION
Extracting the features from index having a new structure:

- Introduction
- Cache
- Constants
- Working with Classes
  - Class Attributes
  - Class Builder
- Deprecations
- Extensions

For now I'm only moving the docs to their own documents

<img width="1192" alt="image" src="https://user-images.githubusercontent.com/1037088/65220554-742e5600-daaa-11e9-843c-40ba3bd6f7c9.png">

