### PR TITLE
Add redirect from gem index

### DIFF
--- a/source/gems/dry-effects/index.html.slim
+++ b/source/gems/dry-effects/index.html.slim
@@ -1,0 +1,6 @@
+---
+title: dry-effects
+layout: gem-index-redirect
+type: gem
+name: dry-effects
+---

--- a/source/layouts/gem-index-redirect.slim
+++ b/source/layouts/gem-index-redirect.slim
@@ -1,0 +1,23 @@
+- path = "/gems/#{current_project.name}/#{current_project.current_version}/"
+
+doctype html
+html lang="en"
+  head
+    = partial("head")
+    link rel="canonical" href="#{path}"
+    meta http-equiv="refresh" content="0; url=#{path}"
+    meta name="robots" content="noindex"
+  body
+    = partial "header-listing"
+    main
+      .row
+        .content-wrap
+          article.content-article
+
+            markdown:
+              The documentation for the current gem version is available under [#{path}](#{path})
+
+              We are redirecting you right now. Please click the link above if the wait is too long
+            script
+              location = "#{path}"
+    = partial "footer"


### PR DESCRIPTION
So we have gem index pages. Right now the page for [dry-effects](https://dry-rb.org/gems/dry-effects/) returns 404.

Now, I've built a simple page that redirects a person to the gem page

The redirect happens pretty fast, and I'm not sure if it's a bad design decision or not. Still works

I tried [middleman's redirect](https://middlemanapp.com/basics/redirects/), but it works in a funny way. So I made my own solution, which looks a bit more user-friendly.

We might figure out a way to render our own custom page, but we'll still need the layout. See [the repo](https://github.com/middleman/middleman/blob/de522927601c1e465634302340e92ed570237470/middleman-core/lib/middleman-core/sitemap/extensions/redirects.rb#L58-L73)

<img width="1297" alt="изображение" src="https://user-images.githubusercontent.com/887264/65818281-d7418a80-e218-11e9-8903-4638c2f20a79.png">
