### PR TITLE
Fix typo on index.html.md

### DIFF
--- a/source/gems/dry-effects/0.1/index.html.md
+++ b/source/gems/dry-effects/0.1/index.html.md
@@ -63,7 +63,7 @@ RSpec.describe CreatePost do
   subject(:create_post) { described_class.new }
 
   it 'updates the counter' do
-    counter, post = with_counter(0) { create_port.(post_values) }
+    counter, post = with_counter(0) { create_post.(post_values) }
 
     expect(counter).to be(1)
   end


### PR DESCRIPTION
I believe this example is meant to be `create_post`