### PR TITLE
Docs on using `dry-types` objects for validation (Closes #362)

### DIFF
--- a/source/gems/dry-types/constraints.html.md
+++ b/source/gems/dry-types/constraints.html.md
@@ -4,7 +4,7 @@ layout: gem-single
 name: dry-types
 ---
 
-## Using Type Objects for Validation
+## Using Constraint Objects for Validation
 
 _Type objects_ can be used to validate that the input satisfies the provided type. There's two approaches to validation.
 

--- a/source/gems/dry-types/constraints.html.md
+++ b/source/gems/dry-types/constraints.html.md
@@ -4,28 +4,92 @@ layout: gem-single
 name: dry-types
 ---
 
-You can create constrained types that will use validation rules to check that the input is not violating any of the configured constraints. You can treat it as a lower level guarantee that you're not instantiating objects that are broken.
+## Using Type Objects for Validation
 
-All types support the constraints API, but not all constraints are suitable for a particular primitive, it's up to you to set up constraints that make sense.
+_Type objects_ can be used to validate that the input satisfies the provided type. There's two approaches to validation.
 
-Under the hood it uses [`dry-logic`](/gems/dry-logic) and all of its predicates are supported.
+### Preferred Approach: Validate using `valid?`
 
-``` ruby
-string = Types::Strict::String.constrained(min_size: 3)
+```ruby
+Dry::Types['strict.string'].valid?(123) # false
+# => false
+Dry::Types['strict.string'].valid?(true)
+# => false
+Dry::Types['strict.string'].valid?("a string")
+# => true
+```
 
-string['foo']
-# => "foo"
+This approach is useful when working with user-provided input.
 
-string['fo']
-# => Dry::Types::ConstraintError: "fo" violates constraints
+### Alternate Approach: Validate by raising an exception
 
-email = Types::Strict::String.constrained(
+```ruby
+Dry::Types['strict.string']["a string"]
+# => "a string"
+
+Dry::Types['strict.string'][123]
+# => 123 violates constraints (type?(String, 123) failed)
+```
+
+## Adding Additional Constraints from the `dry-logic` Gem
+
+`dry-types` objects inherit the ability to attach [`dry-logic`](/gems/dry-logic) requirements by calling `.constrained` on your object:
+
+```ruby
+email = Dry::Types['strict.string'].constrained(
   format: /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z/i
 )
-
+# => #<Dry::Types[Constrained<Nominal<String> rule=[type?(String) AND format?(/\A[\w+\-.]+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z/i)]>]>
 email["jane@doe.org"]
 # => "jane@doe.org"
-
 email["jane"]
-# => Dry::Types::ConstraintError: "jane" violates constraints
+# => "jane" violates constraints (format?(/\A[\w+\-.]+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z/i, "jane") failed)
 ```
+
+Here's a quick glance of the [`dry-logic`](/gems/dry-logic/predicates) predicates, taken from the [`dry-logic`](/gems/dry-logic) docs:
+
+  - `type?`
+  - `none?`
+  - `key?`
+  - `attr?`
+  - `empty?`
+  - `filled?`
+  - `bool?`
+  - `date?`
+  - `date_time?`
+  - `time?`
+  - `number?`
+  - `int?`
+  - `float?`
+  - `decimal?`
+  - `str?`
+  - `hash?`
+  - `array?`
+  - `odd?`
+  - `even?`
+  - `lt?`
+  - `gt?`
+  - `lteq?`
+  - `gteq?`
+  - `size?`
+  - `min_size?`
+  - `max_size?`
+  - `bytesize?`
+  - `min_bytesize?`
+  - `max_bytesize?`
+  - `inclusion?`
+  - `exclusion?`
+  - `included_in?`
+  - `excluded_from?`
+  - `includes?`
+  - `excludes?`
+  - `eql?`
+  - `not_eql?`
+  - `true?`
+  - `false?`
+  - `format?`
+  - `predicate`
+  
+  \* [See the full list here on the `dry-logic` docs](/gems/dry-logic/predicates) 
+
+It's possible to check any input against any type, but it's up to you to set up constraints that make sense.


### PR DESCRIPTION
This is an attempt to improve the `dry-types` docs by expanding and clarifying how developers (like myself) often use them as objects in code.