### PR TITLE
Fix broken links in the news

### DIFF
--- a/source/news/2016-04-07.html.markdown
+++ b/source/news/2016-04-07.html.markdown
@@ -62,4 +62,4 @@ end
 
 And there we have it! With the new infrastructure in place, we could change just two words in our transaction and have long-running jobs pushed into the background queue, while keeping everything just as easy to understand in a single glance.
 
-You can [read more about custom step adapters](http://dry-rb.org/gems/dry-transaction/custom-step-adapters/) in the [dry-transaction documentation](http://dry-rb.org/gems/dry-transaction/) and get started using them with the 0.6.0 release now available on RubyGems. Enjoy!
+You can [read more about custom step adapters](http://dry-rb.org/gems/dry-transaction/0.13/custom-step-adapters/) in the [dry-transaction documentation](http://dry-rb.org/gems/dry-transaction/) and get started using them with the 0.6.0 release now available on RubyGems. Enjoy!

--- a/source/news/2017-05-15.html.markdown
+++ b/source/news/2017-05-15.html.markdown
@@ -45,7 +45,7 @@ class AccountPart < Dry::View::Part
 end
 ```
 
-This is nice, but so far it’s just typical delegator-style behaviour. We can do more: these things are called _view_ parts for a reason! Every view part is initialised with the view’s current [context object](http://dry-rb.org/gems/dry-view/context/) and renderer. This means the view part can now encapsulate much of the logic you’d otherwise have to scatter around your templates.
+This is nice, but so far it’s just typical delegator-style behaviour. We can do more: these things are called _view_ parts for a reason! Every view part is initialised with the view’s current [context object](http://dry-rb.org/gems/dry-view/0.7/context) and renderer. This means the view part can now encapsulate much of the logic you’d otherwise have to scatter around your templates.
 
 Let’s say our context object has `#attachment_url` and `#asset_url` methods, for generating URLs for user-uploaded files and application assets respectively. If you wanted to start showing a profile image for your “account” value, you could now do this:
 
@@ -72,4 +72,4 @@ The result? A cleaner template, and your view logic properly named and encapsula
 
 In this way, view parts provide a critical new layer for placing the majority of your complex view logic. They make your templates easier to understand and easier to work with, and they help ensure that your view layer isn’t where good code structure has to stop.
 
-Want to learn more? Check out [view parts in the dry-view documentation](http://dry-rb.org/gems/dry-view/view-parts/) and give dry-view 0.3.0 a try!
+Want to learn more? Check out [view parts in the dry-view documentation](http://dry-rb.org/gems/dry-view/0.7/parts) and give dry-view 0.3.0 a try!

--- a/source/news/2018-06-26.html.markdown
+++ b/source/news/2018-06-26.html.markdown
@@ -71,7 +71,7 @@ op.(1.0, 0.0) # => Failure(:division_by_zero)
 op.(-1.0, 2.0) # => Failure(:negative_number)
 ```
 
-`DivideThenRoot` can be composed with other objects or methods returning `Result`s in a similar manner. In the end, you can use [`dry-matcher`](/gems/dry-matcher/result-matcher/) for processing the result (or use the `Result`'s [API](/gems/dry-monads/result/) for it).
+`DivideThenRoot` can be composed with other objects or methods returning `Result`s in a similar manner. In the end, you can use [`dry-matcher`](/gems/dry-matcher/0.8/result-matcher) for processing the result (or use the `Result`'s [API](/gems/dry-monads/1.0/result) for it).
 
 Real-life code looks the same in general but usually combines more operations together. Here it can become tedious to use `bind` and `fmap` directly. This is why we added `do` notation in the 1.0 release.
 
@@ -106,7 +106,7 @@ Here it's implied that the `validate`, `create_owner`, `create_account`, and `cr
 
 ## Task
 
-Another highlight from the release is the `Task` monad. Backed by [`concurrent-ruby`](https://github.com/ruby-concurrency/concurrent-ruby), a battle-tested concurrency gem, `Task` can be used for composing asynchronous computations. Essentially, it's a [Promise](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/Promise.html) with a dry-monads-compatible interface.
+Another highlight from the release is the `Task` monad. Backed by [`concurrent-ruby`](https://github.com/ruby-concurrency/concurrent-ruby), a battle-tested concurrency gem, `Task` can be used for composing asynchronous computations. Essentially, it's a [Promise](https://ruby-concurrency.github.io/concurrent-ruby/master/Concurrent/Promises.html) with a dry-monads-compatible interface.
 
 ```ruby
 require 'dry/monads/task'

--- a/source/news/2019-02-12.html.markdown
+++ b/source/news/2019-02-12.html.markdown
@@ -28,7 +28,7 @@ And even with the previous name, we'd still end up calling these things "views" 
 
 ## Automatic part decoration
 
-[Parts](/gems/dry-view/parts/) are a major reason to use dry-view: they offer an easy, integrated place for encapsulating view-specific behaviour alongside the data it relates to.
+[Parts](/gems/dry-view/0.7/parts) are a major reason to use dry-view: they offer an easy, integrated place for encapsulating view-specific behaviour alongside the data it relates to.
 
 Until now, however, using a broad range of part classes involved specifying those classes by name, directly, for every exposure.
 
@@ -76,7 +76,7 @@ Along with this, parts can now be accessed via a new `Dry::View::Rendered` objec
 
 ## Customizable scopes!
 
-Until now, we’ve had exposures and parts to pass values to the template along with their view-specific behavior, and the context object to provide behavior common to all templates. But what about behavior that we want to provide to just a _single_ template or partial?For this, we now have [customizable scopes](/gems/dry-view/scopes/).
+Until now, we’ve had exposures and parts to pass values to the template along with their view-specific behavior, and the context object to provide behavior common to all templates. But what about behavior that we want to provide to just a _single_ template or partial?For this, we now have [customizable scopes](/gems/dry-view/0.7/scopes).
 
 Unlike parts, which decorate a single value, scopes have access to a template’s entire set of locals (as well as the context object, plus the methods to render partial or build other scopes). This gives you another logical place to provide some custom view behavior that can still access all the other features of the system.
 
@@ -127,7 +127,7 @@ Rendering a scope like this will look for a partial matching the scope’s own n
 
 ## Context object can decorate attributes
 
-[Context](/gems/dry-view/context) classes must now inherit from `Dry::View::Context`. This brings the ability for context classes to specify which of their attributes should be decorated with parts.
+[Context](/gems/dry-view/0.7/context) classes must now inherit from `Dry::View::Context`. This brings the ability for context classes to specify which of their attributes should be decorated with parts.
 
 For example, for a context with an injected `assets` dependency, specifying `decorate :assets` would have the assets object wrapped in a matching part class (e.g. `Parts::Assets` if the view currently rendering has a `part_namespace` of `Parts`).
 
@@ -195,7 +195,7 @@ Makes sense, right? Turns out this isn’t possible with the other popular Ruby 
 
 ## Easier unit testing for Parts and Scopes
 
-Parts and scopes can now be more easily [unit tested](/gems/dry-view/testing/).
+Parts and scopes can now be more easily [unit tested](/gems/dry-view/0.7/testing).
 
 If you want to unit test the aspects of the class that don’t require a full rendering environment, you can now instantiate a Part with its value alone:
 
@@ -213,7 +213,7 @@ part_for_testing = Parts::Article.new(
 )
 ```
 
-For more detailed unit testing examples, see the [dry-view testing documentation](/gems/dry-view/testing/).
+For more detailed unit testing examples, see the [dry-view testing documentation](/gems/dry-view/0.7/testing).
 
 ## And more!
 

--- a/source/news/2019-06-10.html.markdown
+++ b/source/news/2019-06-10.html.markdown
@@ -190,7 +190,7 @@ Additionally, check out:
 - dry-types 1.0.0 [CHANGELOG](https://github.com/dry-rb/dry-types/blob/master/CHANGELOG.md#v100-2019-04-23)
 - dry-schema 1.0.0 [CHANGELOG](https://github.com/dry-rb/dry-schema/blob/master/CHANGELOG.md)s
 
-If you need help with upgrading, **please do not hesitate to ask questions either on our [discussion forum](https://discourse.dry-rb.org) or [community chat](https://dry-rb.zulipchat.org)**.
+If you need help with upgrading, **please do not hesitate to ask questions either on our [discussion forum](https://discourse.dry-rb.org) or [community chat](https://dry-rb.zulipchat.com)**.
 
 ## Thank you
 


### PR DESCRIPTION
It's a bit strange to link to 0.7 version within the article about 0.6 release of a gem, but it's better than a broken link =)