### PR TITLE
Fix the projects:symlink script run instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install
 Clone and symlink docsites from individual dry-rb repositories:
 
 ```
-bundle exec projects:symlink
+bundle exec rake projects:symlink
 ```
 
 Start Middleman server:


### PR DESCRIPTION
The projects:symlink is a rake task, just copying the command from readme returns an error
and it is an unnecessary delay thrown at the potencial commiters