### PR TITLE
Add external resources page to the website

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,7 +210,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport
   better_errors
   binding_of_caller
   builder (~> 3.0)
@@ -225,14 +224,12 @@ DEPENDENCIES
   middleman-syntax
   mime-types
   puma
-  rack
   rack-contrib
   rake
   redcarpet
   sanitize
   slim
   tilt-jbuilder
-  tzinfo
 
 BUNDLED WITH
    2.1.4

--- a/source/partials/_nav.slim
+++ b/source/partials/_nav.slim
@@ -19,6 +19,8 @@ nav.main-nav
       a href="/status" Status
     li class=("main-nav__item--selected" if /\Anews/.match(current_page.path))
       a href="/news" News
+    li class=("main-nav__item--selected" if /\Aresources/.match(current_page.path))
+      a href="/resources" Resources
     li class=("main-nav__item--selected" if /\Acommunity/.match(current_page.path))
       a href="/community" Community
     br.mobile-only

--- a/source/resources.html.slim
+++ b/source/resources.html.slim
@@ -1,0 +1,14 @@
+---
+title: External Resources
+layout: content-page
+---
+
+.community-resources
+  h1 Community resources
+
+  p As dry-rb community grows, <strong>there are more and more poeple writing, or talking about us</strong>! Here is the list of some of the talks and resources you can learn more from about our libraries.
+
+  ul
+    li
+      a href="https://hanamimastery.com/t/dry-rb" Hanami Mastery (DRY-RB tag)
+      | - a collection of articles and video tutorials about dry-rb gems


### PR DESCRIPTION
### Overview

As `dry-rb` community grows, more and more valuable resources appear on the web related to the
ecosystem. 

It is useful to allow for the easy addition of such learning resources.

It took me a while, but I've finally had a chance to prepare such concept:

![image](https://user-images.githubusercontent.com/8088317/135760668-3b194e83-b598-49eb-96f4-14f385736612.png)
