### PR TITLE
Explain `.()` is `.call()` on homepage

### DIFF
--- a/source/index.html.slim
+++ b/source/index.html.slim
@@ -31,7 +31,7 @@ title: Home
 
                 contract = NewUserContract.new
 
-                contract.("name" => "Jane", "age" => "30").success?
+                contract.("name" => "Jane", "age" => "30").success? # .() is a Ruby shortcut for .call()
                 # => true
 
                 contract.("name" => "Jane", "age" => "17").failure?


### PR DESCRIPTION
That `foo.(...)` is syntactic sugar for `foo.call(...)` isn't something every Rubyist knows. It's not a very commonly used idiom (yet?!).

Although it's convenient short-hand, it looks quite strange to people who don't know what it is. It's alao hard to search for ("nameless method"?)

Especially since `dry-rb` introduces many concepts that will be new to Rubyists, I don't think the `#()` = `#call()` trick is something that it makes sense to highlight on the homepage.

(There are also many other instances, but only in the blog. Happy to update those too, but think this is higher priority.)