### PR TITLE
dry-types: Publish docs for latest stable release

### DIFF
--- a/data/projects.yml
+++ b/data/projects.yml
@@ -51,6 +51,8 @@
 - name: dry-types
   desc: Flexible type system with many built-in types
   versions:
+    - value: "1.7"
+      branch: "release-1.7"
     - value: "1.2"
       branch: "release-1.2"
     - value: "1.0"


### PR DESCRIPTION
I finally realized I was looking at outdated documentation when I debugged why a [docs bugfix][1] wasn't live yet.

Because looking at "main" would make me nervous (hard to know which features have been released and which haven't), I propose to publish the documentation for the latest published minor version as well.

[1]: https://github.com/dry-rb/dry-types/commit/159d733717f072de0ba1fbf9e16933ddf323a3fd