### PR TITLE
Sort project versions

### DIFF
--- a/data/projects.yml
+++ b/data/projects.yml
@@ -4,155 +4,155 @@
   versions:
   - value: '1.10'
     branch: release-1.10
-  - value: main
-    branch: main
-  - value: '1.6'
-    branch: release-1.6
-  - value: '0.13'
-    branch: release-0.13
-  - value: '1.3'
-    branch: release-1.3
-  - value: '1.1'
-    branch: release-1.1
   - value: '1.9'
     branch: release-1.9
   - value: '1.8'
     branch: release-1.8
-  - value: '1.5'
-    branch: release-1.5
-  - value: '1.2'
-    branch: release-1.2
-  - value: '1.0'
-    branch: release-1.0
   - value: '1.7'
     branch: release-1.7
+  - value: '1.6'
+    branch: release-1.6
+  - value: '1.5'
+    branch: release-1.5
   - value: '1.4'
     branch: release-1.4
+  - value: '1.3'
+    branch: release-1.3
+  - value: '1.2'
+    branch: release-1.2
+  - value: '1.1'
+    branch: release-1.1
+  - value: '1.0'
+    branch: release-1.0
+  - value: '0.13'
+    branch: release-0.13
+  - value: main
+    branch: main
   seo:
     description: The standalone validation library for Ruby
 - name: dry-schema
   desc: Schema coercion & validation
   versions:
-  - value: '1.0'
-    branch: release-1.0
-  - value: main
-    branch: main
-  - value: '1.12'
-    branch: release-1.12
-  - value: '1.4'
-    branch: release-1.4
-  - value: '1.11'
-    branch: release-1.11
   - value: '1.13'
     branch: release-1.13
+  - value: '1.12'
+    branch: release-1.12
+  - value: '1.11'
+    branch: release-1.11
+  - value: '1.10'
+    branch: release-1.10
+  - value: '1.9'
+    branch: release-1.9
   - value: '1.8'
     branch: release-1.8
   - value: '1.7'
     branch: release-1.7
   - value: '1.6'
     branch: release-1.6
-  - value: '1.9'
-    branch: release-1.9
   - value: '1.5'
     branch: release-1.5
-  - value: '1.10'
-    branch: release-1.10
+  - value: '1.4'
+    branch: release-1.4
+  - value: '1.0'
+    branch: release-1.0
+  - value: main
+    branch: main
   seo:
     description: Flexible validation library for data structures in Ruby
 - name: dry-types
   desc: Flexible type system with many built-in types
   versions:
-  - value: '1.2'
-    branch: release-1.2
-  - value: main
-    branch: main
   - value: '1.7'
     branch: release-1.7
-  - value: '1.3'
-    branch: release-1.3
-  - value: '0.15'
-    branch: release-0.15
   - value: '1.6'
     branch: release-1.6
-  - value: '1.0'
-    branch: release-1.0
-  - value: '1.4'
-    branch: release-1.4
   - value: '1.5'
     branch: release-1.5
+  - value: '1.4'
+    branch: release-1.4
+  - value: '1.3'
+    branch: release-1.3
+  - value: '1.2'
+    branch: release-1.2
+  - value: '1.0'
+    branch: release-1.0
+  - value: '0.15'
+    branch: release-0.15
+  - value: main
+    branch: main
   seo:
     description: Flexible type system for Ruby
 - name: dry-struct
   desc: Attribute DSL for struct-like objects
   versions:
-  - value: '1.1'
-    branch: release-1.1
-  - value: main
-    branch: main
   - value: '1.6'
     branch: release-1.6
-  - value: '1.2'
-    branch: release-1.2
-  - value: '1.0'
-    branch: release-1.0
   - value: '1.5'
     branch: release-1.5
-  - value: '0.7'
-    branch: release-0.7
-  - value: '1.3'
-    branch: release-1.3
   - value: '1.4'
     branch: release-1.4
+  - value: '1.3'
+    branch: release-1.3
+  - value: '1.2'
+    branch: release-1.2
+  - value: '1.1'
+    branch: release-1.1
+  - value: '1.0'
+    branch: release-1.0
+  - value: '0.7'
+    branch: release-0.7
+  - value: main
+    branch: main
   seo:
     description: The easiest and most powerful way to build struct and value objects
       in Ruby
 - name: dry-transaction
   desc: Business transaction DSL
   versions:
-  - value: main
-    branch: main
   - value: '0.15'
     branch: release-0.15
-  - value: '0.1'
-    branch: release-0.1
-  - value: '0.13'
-    branch: release-0.13
   - value: '0.14'
     branch: release-0.14
+  - value: '0.13'
+    branch: release-0.13
+  - value: '0.1'
+    branch: release-0.1
+  - value: main
+    branch: main
   seo:
     description: Business transaction DSL for Ruby
 - name: dry-container
   desc: Simple and thread-safe IoC container
   versions:
-  - value: main
-    branch: main
-  - value: '0.8'
-    branch: release-0.8
+  - value: '0.11'
+    branch: release-0.11
   - value: '0.10'
     branch: release-0.10
+  - value: '0.8'
+    branch: release-0.8
   - value: '0.7'
     branch: release-0.7
   - value: '0.1'
     branch: release-0.1
-  - value: '0.11'
-    branch: release-0.11
+  - value: main
+    branch: main
   seo:
     description: A simple, configurable object container implemented in Ruby
 - name: dry-auto_inject
   desc: Container-agnostic constructor injection mixin
   versions:
-  - value: main
-    branch: main
   - value: '1.0'
     branch: release-1.0
-  - value: '0.8'
-    branch: release-0.8
-  - value: '0.6'
-    branch: release-0.6
-  - value: '0.7'
-    branch: release-0.7
   - value: '0.9'
     branch: release-0.9
+  - value: '0.8'
+    branch: release-0.8
+  - value: '0.7'
+    branch: release-0.7
+  - value: '0.6'
+    branch: release-0.6
+  - value: main
+    branch: main
   seo:
     description: Bring dependency injection to your Ruby application
 - name: dry-equalizer
@@ -168,122 +168,122 @@
 - name: dry-inflector
   desc: Standalone inflections
   versions:
-  - value: main
-    branch: main
   - value: '1.0'
     branch: release-1.0
+  - value: '0.3'
+    branch: release-0.3
   - value: '0.2'
     branch: release-0.2
   - value: '0.1'
     branch: release-0.1
-  - value: '0.3'
-    branch: release-0.3
+  - value: main
+    branch: main
   seo:
     description: A Ruby library to transform human-friendly strings to machine-friendly
       strings, and vice-versa
 - name: dry-system
   desc: Organize your code into reusable components
   versions:
+  - value: '1.0'
+    branch: release-1.0
+  - value: '0.27'
+    branch: release-0.27
+  - value: '0.26'
+    branch: release-0.26
+  - value: '0.25'
+    branch: release-0.25
+  - value: '0.24'
+    branch: release-0.24
+  - value: '0.23'
+    branch: release-0.23
+  - value: '0.22'
+    branch: release-0.22
+  - value: '0.21'
+    branch: release-0.21
+  - value: '0.20'
+    branch: release-0.20
+  - value: '0.19'
+    branch: release-0.19
+  - value: '0.18'
+    branch: release-0.18
+  - value: '0.17'
+    branch: release-0.17
+  - value: '0.16'
+    branch: release-0.16
   - value: '0.15'
     branch: release-0.15
-  - value: main
-    branch: main
+  - value: '0.14'
+    branch: release-0.14
+  - value: '0.12'
+    branch: release-0.12
   - value: '0.2'
     branch: release-0.2
   - value: '0.1'
     branch: release-0.1
-  - value: '0.12'
-    branch: release-0.12
-  - value: '0.23'
-    branch: release-0.23
-  - value: '0.18'
-    branch: release-0.18
-  - value: '1.0'
-    branch: release-1.0
-  - value: '0.21'
-    branch: release-0.21
-  - value: '0.22'
-    branch: release-0.22
-  - value: '0.16'
-    branch: release-0.16
-  - value: '0.17'
-    branch: release-0.17
-  - value: '0.27'
-    branch: release-0.27
-  - value: '0.14'
-    branch: release-0.14
-  - value: '0.20'
-    branch: release-0.20
-  - value: '0.24'
-    branch: release-0.24
-  - value: '0.25'
-    branch: release-0.25
-  - value: '0.19'
-    branch: release-0.19
-  - value: '0.26'
-    branch: release-0.26
+  - value: main
+    branch: main
   seo:
     description: Organize your Ruby code into reusable components
 - name: dry-configurable
   desc: Thread-safe configuration mixin
   versions:
+  - value: '1.0'
+    branch: release-1.0
   - value: '0.16'
     branch: release-0.16
-  - value: main
-    branch: main
   - value: '0.15'
     branch: release-0.15
   - value: '0.14'
     branch: release-0.14
-  - value: '0.1'
-    branch: release-0.1
-  - value: '1.0'
-    branch: release-1.0
-  - value: '0.10'
-    branch: release-0.10
-  - value: '0.11'
-    branch: release-0.11
-  - value: '0.12'
-    branch: release-0.12
-  - value: '0.9'
-    branch: release-0.9
   - value: '0.13'
     branch: release-0.13
+  - value: '0.12'
+    branch: release-0.12
+  - value: '0.11'
+    branch: release-0.11
+  - value: '0.10'
+    branch: release-0.10
+  - value: '0.9'
+    branch: release-0.9
   - value: '0.8'
     branch: release-0.8
+  - value: '0.1'
+    branch: release-0.1
+  - value: main
+    branch: main
   seo:
     description: A simple mixin to make Ruby classes configurable
 - name: dry-initializer
   desc: DSL for defining initializer params and options
   versions:
-  - value: main
-    branch: main
   - value: '3.1'
     branch: release-3.1
   - value: '3.0'
     branch: release-3.0
   - value: '0.4'
     branch: release-0.4
+  - value: main
+    branch: main
   seo:
     description: A dead simple library for initializing Ruby classes with params and
       options
 - name: dry-logic
   desc: Predicate logic with composable rules
   versions:
-  - value: main
-    branch: main
   - value: '1.5'
     branch: release-1.5
+  - value: '1.4'
+    branch: release-1.4
   - value: '1.3'
     branch: release-1.3
   - value: '1.2'
     branch: release-1.2
-  - value: '1.0'
-    branch: release-1.0
   - value: '1.1'
     branch: release-1.1
-  - value: '1.4'
-    branch: release-1.4
+  - value: '1.0'
+    branch: release-1.0
+  - value: main
+    branch: main
   seo:
     description: Predicate logic with rule composition for Ruby
 - name: dry-logger
@@ -298,29 +298,29 @@
 - name: dry-matcher
   desc: Flexible, expressive pattern matching
   versions:
-  - value: main
-    branch: main
-  - value: '0.9'
-    branch: release-0.9
-  - value: '0.1'
-    branch: release-0.1
-  - value: '0.8'
-    branch: release-0.8
-  - value: '0.7'
-    branch: release-0.7
   - value: '1.0'
     branch: release-1.0
   - value: '0.10'
     branch: release-0.10
+  - value: '0.9'
+    branch: release-0.9
+  - value: '0.8'
+    branch: release-0.8
+  - value: '0.7'
+    branch: release-0.7
+  - value: '0.1'
+    branch: release-0.1
+  - value: main
+    branch: main
   seo:
     description: Flexible, expressive pattern matching for Ruby
 - name: dry-monads
   desc: Useful, common monads in idiomatic Ruby
   versions:
-  - value: main
-    branch: main
   - value: '1.6'
     branch: release-1.6
+  - value: '1.5'
+    branch: release-1.5
   - value: '1.4'
     branch: release-1.4
   - value: '1.3'
@@ -329,8 +329,8 @@
     branch: release-1.0
   - value: '0.4'
     branch: release-0.4
-  - value: '1.5'
-    branch: release-1.5
+  - value: main
+    branch: main
   seo:
     description: Useful, common monads in idiomatic Ruby
 - name: dry-view
@@ -345,103 +345,103 @@
 - name: dry-core
   desc: A toolset of small support modules used throughout the dry-rb & rom-rb ecosystems
   versions:
-  - value: '0.4'
-    branch: release-0.4
-  - value: main
-    branch: main
+  - value: '1.0'
+    branch: release-1.0
+  - value: '0.9'
+    branch: release-0.9
   - value: '0.8'
     branch: release-0.8
   - value: '0.7'
     branch: release-0.7
-  - value: '0.5'
-    branch: release-0.5
-  - value: '0.9'
-    branch: release-0.9
-  - value: '1.0'
-    branch: release-1.0
   - value: '0.6'
     branch: release-0.6
+  - value: '0.5'
+    branch: release-0.5
+  - value: '0.4'
+    branch: release-0.4
+  - value: main
+    branch: main
   seo:
     description: A toolset of small support modules used throughout the @dry-rb &
       @rom-rb ecosystems
 - name: dry-events
   desc: Standalone pub/sub API
   versions:
-  - value: main
-    branch: main
   - value: '1.0'
     branch: release-1.0
+  - value: '0.4'
+    branch: release-0.4
   - value: '0.3'
     branch: release-0.3
   - value: '0.2'
     branch: release-0.2
-  - value: '0.4'
-    branch: release-0.4
+  - value: main
+    branch: main
   seo:
     description: A convienent publisher-subscriber framework for Ruby
 - name: dry-effects
   desc: Algebraic effects in Ruby
   versions:
-  - value: main
-    branch: main
   - value: '0.4'
     branch: release-0.4
+  - value: '0.3'
+    branch: release-0.3
   - value: '0.2'
     branch: release-0.2
   - value: '0.1'
     branch: release-0.1
-  - value: '0.3'
-    branch: release-0.3
+  - value: main
+    branch: main
   seo:
     description: A practical, production-grade implementation of algebraic effects
       for Ruby
 - name: dry-cli
   desc: General purpose Command Line Interface (CLI) framework
   versions:
-  - value: main
-    branch: main
-  - value: '0.7'
-    branch: release-0.7
   - value: '1.0'
     branch: release-1.0
+  - value: '0.7'
+    branch: release-0.7
   - value: '0.6'
     branch: release-0.6
-  - value: '0.4'
-    branch: release-0.4
   - value: '0.5'
     branch: release-0.5
+  - value: '0.4'
+    branch: release-0.4
+  - value: main
+    branch: main
   seo:
     description: General purpose Command Line Interface (CLI) framework for Ruby
 - name: dry-transformer
   desc: Data transformation toolkit
   versions:
-  - value: main
-    branch: main
   - value: '1.0'
     branch: release-1.0
   - value: '0.1'
     branch: release-0.1
+  - value: main
+    branch: main
   seo:
     description: The data transformation toolkit for Ruby
 - name: dry-rails
   desc: The dry-rb railtie
   versions:
-  - value: '0.3'
-    branch: release-0.3
-  - value: main
-    branch: main
+  - value: '0.7'
+    branch: release-0.7
   - value: '0.6'
     branch: release-0.6
   - value: '0.5'
     branch: release-0.5
   - value: '0.4'
     branch: release-0.4
-  - value: '0.7'
-    branch: release-0.7
+  - value: '0.3'
+    branch: release-0.3
   - value: '0.2'
     branch: release-0.2
   - value: '0.1'
     branch: release-0.1
+  - value: main
+    branch: main
   seo:
     description: Bring the power of DRY.rb to your Ruby on Rails application
 - name: dry-files
@@ -449,24 +449,24 @@
   versions:
   - value: '1.0'
     branch: release-1.0
+  - value: '0.3'
+    branch: release-0.3
   - value: '0.2'
     branch: release-0.2
   - value: '0.1'
     branch: release-0.1
-  - value: '0.3'
-    branch: release-0.3
   seo:
     description: Provides useful abstractions for file manipulation in Ruby
 - name: dry-monitor
   desc: Instrumentation for Ruby applications
   versions:
-  - value: main
-    branch: main
-  - value: '0.7'
-    branch: release-0.7
   - value: '1.0'
     branch: release-1.0
+  - value: '0.7'
+    branch: release-0.7
   - value: '0.6'
     branch: release-0.6
+  - value: main
+    branch: main
   seo:
     description: A set of instrumentation APIs and tools for any Ruby application


### PR DESCRIPTION
This is a partial fix for #400. I'll do a PR in [dry-rb/devtools](https://github.com/dry-rb/devtools) with the matching tooling change.

For the record, this ordering is what we get with:

```ruby
project_versions.sort_by! { |entry| entry["value"].split(".").map(&:to_i) }.reverse!
```

I looked at a [previous version of projects.yml](https://github.com/dry-rb/dry-rb.org/blob/3ea53e94d13bd5e4162b625f190dfb7a656caa21/data/projects.yml), and it looks like most projects used to be in descending version order, with `main` last.

I could see some value in moving `main` first in the list, since it's even more recent than the last numbered version. The code for that would be a little more involved, but it's doable if that's preferred. :)