### PR TITLE
Remove non-existant columns from the Status page description

### DIFF
--- a/source/status.html.slim
+++ b/source/status.html.slim
@@ -9,7 +9,7 @@ p
   | First of all you can see a list of all dry-rb libraries with their actual versions and build status.
 
 p
-  | If you want to participate and help us, this page can help you too. You can easily find a project that needs your help based on Issues, Pull Requests, CodeClimate, Test Coverage and Doc Coverage columns.
+  | If you want to participate and help us, this page can help you too. You can easily find a project that needs your help based on Issues, Pull Requests and Doc Coverage columns.
 
 .statuses
   .statuses__wrapper


### PR DESCRIPTION
Just a small cleanup: these columns do not exist in the status table, so we shouldn't tell people to look for them.